### PR TITLE
Fixes for Python3

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -90,6 +90,8 @@ def _markerColorCheck(mc, X, Y, L):
     assert (mc <= 255).all(), 'marker colors have to be <= 255'
     assert (mc == np.floor(mc)).all(), 'marker colors are assumed to be ints'
 
+    mc = np.int8(mc)
+
     if mc.ndim == 1:
         markercolor = mc.tolist()
     else:

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -281,7 +281,7 @@ class Visdom(object):
         assert win is not None
 
         assert Y.shape == X.shape, 'Y should be same size as X'
-        if X.shape > 2:
+        if X.ndim > 2:
             X = np.squeeze(X)
             Y = np.squeeze(Y)
         assert X.ndim == 1 or X.ndim == 2, 'Updated X should be 1 or 2 dim'

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -475,8 +475,8 @@ class Visdom(object):
 
         assert X.ndim == 2, 'data should be two-dimensional'
         opts = {} if opts is None else opts
-        opts['xmin'] = opts.get('xmin', float(X.min()))
-        opts['xmax'] = opts.get('xmax', float(X.max()))
+        opts['xmin'] = opts.get('xmin', np.asscalar(X.min()))
+        opts['xmax'] = opts.get('xmax', np.asscalar(X.max()))
         opts['colormap'] = opts.get('colormap', 'Viridis')
         _assert_opts(opts)
 

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -475,8 +475,8 @@ class Visdom(object):
 
         assert X.ndim == 2, 'data should be two-dimensional'
         opts = {} if opts is None else opts
-        opts['xmin'] = opts.get('xmin', X.min())
-        opts['xmax'] = opts.get('xmax', X.max())
+        opts['xmin'] = opts.get('xmin', float(X.min()))
+        opts['xmax'] = opts.get('xmax', float(X.max()))
         opts['colormap'] = opts.get('colormap', 'Viridis')
         _assert_opts(opts)
 


### PR DESCRIPTION
This PR fixes 3 issues that showed up when I ran `examples/demo.py` with Python3.5:

Commit fffb54f solves
```
Traceback (most recent call last):
  File "example/demo.py", line 67, in <module>
    markercolor=np.floor(np.random.random((2, 3)) * 255),
  File "/usr/local/lib/python3.5/site-packages/visdom/__init__.py", line 356, in scatter
    opts['markercolor'], X, Y, K)
  File "/usr/local/lib/python3.5/site-packages/visdom/__init__.py", line 97, in _markerColorCheck
    markercolor = ['#%x%x%x' % (i[0], i[1], i[2]) for i in mc]
  File "/usr/local/lib/python3.5/site-packages/visdom/__init__.py", line 97, in <listcomp>
    markercolor = ['#%x%x%x' % (i[0], i[1], i[2]) for i in mc]
TypeError: %x format: an integer is required, not numpy.float64
```

Commit 02bf99b solves (this was actually a bug, not a Python3 issue)
```
Traceback (most recent call last):
  File "example/demo.py", line 84, in <module>
    name='new_trace',
  File "/usr/local/lib/python3.5/site-packages/visdom/__init__.py", line 284, in updateTrace
    if X.shape > 2:
TypeError: unorderable types: tuple() > int()
```

Commit b1f41c7 solves
```
Traceback (most recent call last):
  File "example/demo.py", line 115, in <module>
    colormap='Electric',
  File "/usr/local/lib/python3.5/site-packages/visdom/__init__.py", line 506, in heatmap
    'layout': _opts2layout(opts)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/__init__.py", line 230, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/encoder.py", line 198, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/encoder.py", line 256, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/encoder.py", line 179, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: 1 is not JSON serializable
```

Thanks for the great tool, I was hoping the heir of `display` in Torch would materialize eventually.