### PR TITLE
Fix line plot update bug 

### DIFF
--- a/example/demo.py
+++ b/example/demo.py
@@ -142,12 +142,12 @@ win = viz.line(
 )
 viz.line(
     X=np.column_stack((np.arange(10, 20), np.arange(10, 20))),
-    Y=np.column_stack((np.linspace(5, 10, 10), np.linspace(5, 10, 10))),
+    Y=np.column_stack((np.linspace(5, 10, 10), np.linspace(5, 10, 10) + 5)),
     win=win,
     update='append'
 )
 viz.updateTrace(
-    X=np.arange(11, 20),
+    X=np.arange(21, 30),
     Y=np.arange(1, 10),
     win=win,
     name='2'

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -298,7 +298,7 @@ class Visdom(object):
             assert len(name) >= 0, 'name of trace should be nonempty string'
             assert X.ndim == 1, 'updating by name expects 1-dim data'
 
-        data = {'x': X.tolist(), 'y': Y.tolist()}
+        data = {'x': X.transpose().tolist(), 'y': Y.transpose().tolist()}
         if X.ndim == 1:
             data['x'] = [data['x']]
             data['y'] = [data['y']]


### PR DESCRIPTION
This is a fix to Issue [#7](https://github.com/facebookresearch/visdom/issues/7)

When building the initial line plot, the code reveals the data in column ('F') order. However, in the `updateTrace` call, `tolist()` function will make the nested list in row order. A simple fix is to add a transpose operation before calling `tolist`. 

I also update the example in `demo.py` showing this change fixes the bug we observed earlier. 