### PR TITLE
Add mathjax library

### DIFF
--- a/py/static/index.html
+++ b/py/static/index.html
@@ -31,6 +31,9 @@ LICENSE file in the root directory of this source tree.
     <script src="https://unpkg.com/layout-bin-packer@1.2.2"></script>
     <script src="https://cdn.rawgit.com/STRML/react-grid-layout/0.14.0/dist/react-grid-layout.min.js"></script>
 
+    <!-- Mathjax -->
+    <script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG"></script>
+
     <!-- Plotly -->
     <script src="https://cdn.rawgit.com/plotly/plotly.js/master/dist/plotly.min.js"></script>
 


### PR DESCRIPTION
Including mathjax allows using LaTeX expressions in titles, legends, and labels, e.g.: https://plot.ly/javascript/LaTeX/