### PR TITLE
Escape eid before saving

### DIFF
--- a/py/server.py
+++ b/py/server.py
@@ -89,8 +89,6 @@ def serialize_env(state, eids):
     l = [i for i in eids if i in state]
     for i in l:
         p = '%s/%s.json' % (FLAGS.env_path, i)
-        print('serialize')
-        print(state)
         open(p, 'w').write(json.dumps(state[i]))
     return l
 
@@ -118,8 +116,6 @@ class Application(tornado.web.Application):
             state['main'] = {'jsons': {}, 'reload': {}}
             serialize_env(state, ['main'])
 
-        print('Application')
-        print(state)
         handlers = [
             (r"/events", PostHandler, dict(state=state, subs=subs)),
             (r"/update", UpdateHandler, dict(state=state, subs=subs)),

--- a/py/server.py
+++ b/py/server.py
@@ -60,15 +60,20 @@ def get_path(filename):
     return os.path.join(cwd, filename)
 
 
+def escape_eid(eid):
+    """Replace slashes with underscores, to avoid recognizing them
+    as directories.
+    """
+
+    return eid.replace('/', '_')
+
+
 def extract_eid(args):
     """Extract eid from args. If eid does not exist in args,
     it returns 'main'."""
 
     eid = 'main' if args.get('eid') is None else args.get('eid')
-    # Replace slashes with underscores, to avoid recognizing them
-    # as directories.
-    eid = eid.replace('/', '_')
-    return eid
+    return escape_eid(eid)
 
 
 tornado_settings = {
@@ -84,6 +89,8 @@ def serialize_env(state, eids):
     l = [i for i in eids if i in state]
     for i in l:
         p = '%s/%s.json' % (FLAGS.env_path, i)
+        print('serialize')
+        print(state)
         open(p, 'w').write(json.dumps(state[i]))
     return l
 
@@ -111,6 +118,8 @@ class Application(tornado.web.Application):
             state['main'] = {'jsons': {}, 'reload': {}}
             serialize_env(state, ['main'])
 
+        print('Application')
+        print(state)
         handlers = [
             (r"/events", PostHandler, dict(state=state, subs=subs)),
             (r"/update", UpdateHandler, dict(state=state, subs=subs)),
@@ -155,6 +164,7 @@ class SocketHandler(tornado.websocket.WebSocketHandler):
         elif cmd == 'save':
             # save localStorage pane metadata
             if 'data' in msg and 'eid' in msg:
+                msg['eid'] = escape_eid(msg['eid'])
                 self.state[msg['eid']] = copy.deepcopy(self.state[msg['prev_eid']])
                 self.state[msg['eid']]['reload'] = msg['data']
                 self.eid = msg['eid']
@@ -390,6 +400,7 @@ class SaveHandler(BaseHandler):
 
     def post(self):
         envs = tornado.escape.json_decode(tornado.escape.to_basestring(self.request.body))['data']
+        envs = [escape_eid(eid) for eid in envs]
         ret = serialize_env(self.state, envs)  # this ignores invalid env ids
         self.write(json.dumps(ret))
 


### PR DESCRIPTION
I am sorry that my previous PR does not cover all erroneous cases!
This PR extends my previous PR by adding the below features:

1) When saving from the web page, (i.e. via SocketHandler) it replaces slashes to underscores.
2) When saving programatically, (i.e. via SaveHandler) it escpaes all eids in a parameter list.

I've tested the above two cases and verified that in all of them it can save environments as expected.