### PR TITLE
Fix for CxHxW when image is called with ndim=2

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -306,7 +306,7 @@ class Visdom(object):
 
         nchannels = img.shape[0] if img.ndim == 3 else 1
         if nchannels == 1:
-            img = img[:, :, np.newaxis].repeat(3, axis=2)
+            img = img[np.newaxis, :, :].repeat(3, axis=0)
 
         if 'float' in str(img.dtype):
             if img.max() <= 1:


### PR DESCRIPTION
This commit fixes the following exception, occurring when `image` is called with a 2d array, such as `vis.image(np.ones((10,10)))`. The error is debris from the CxHxW changes.

```
>>> import visdom
>>> import numpy as np
>>> vis = visdom.Visdom()
>>> vis.image(np.ones((10,10)))
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/PIL/Image.py", line 2195, in fromarray
    mode, rawmode = _fromarray_typemap[typekey]
KeyError: ((1, 1, 30), '|u1')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.5/site-packages/visdom/__init__.py", line 179, in result
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/visdom/__init__.py", line 318, in image
    im = Image.fromarray(img)
  File "/usr/local/lib/python3.5/site-packages/PIL/Image.py", line 2198, in fromarray
    raise TypeError("Cannot handle this data type")
TypeError: Cannot handle this data type
```
