### PR TITLE
Change `opts` to `options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ import visdom
 import numpy as np
 vis = visdom.Visdom()
 vis.text('Hello, world!')
-vis.image(np.ones((10, 10, 3)))
+vis.image(np.ones((3, 10, 10)))
 ```
 
 #### Torch example

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The following API is currently supported. Visualizations are powered by [Plotly]
 - `vis.quiver`   : quiver plots
 - `vis.image`    : images
 - `vis.text`     : text box
+- `vis.mesh`     : mesh plots
 - `vis.save`     : serialize state
 
 Further details on each of these functions are given below. For a quick introduction into the capabilities of `visdom`, have a look at the `example` directory, or read the details below.
@@ -303,6 +304,15 @@ the name of an SVG file `svgfile`. The function does not support any specific
 This function prints text in a  box. It takes as input a `text` string.
 No specific `options` are currently supported.
 
+### plot.mesh
+This function draws a mesh plot from a set of vertices defined in an
+`Nx2` or `Nx3` matrix `X`, and polygons defined in an optional `Mx2` or
+`Mx3` matrix `Y`.
+
+The following `options` are supported:
+
+- `options.color`: color (`string`)
+- `options.opacity`: opacity of polygons (`number` between 0 and 1)
 
 ### Customizing plots
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,16 @@ The following `options` are supported:
 
 - `options.jpgquality`: JPG quality (`number` 0-100; default = 100)
 
+### plot.video
+This function plays a video. It takes as input the filename of the video
+`videofile` or a `LxCxHxW`-sized `tensor` (in Lua) or a or a `LxHxWxC`-sized
+`tensor` (in Python) containing all the frames of the video as input. The
+function does not support any plot-specific `options`.
+
+Note: Using `tensor` input requires that ffmpeg is installed and working.
+Your ability to play video may depend on the browser you use: your browser has
+to support the Theano codec in an OGG container (Chrome supports this).
+
 ### plot.svg
 This function draws an SVG object. It takes as input a SVG string `svgstr` or
 the name of an SVG file `svgfile`. The function does not support any specific

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Visdom offers the following basic visualization functions:
 - `vis.save`     : serialize state server-side
 
 ### Plotting
-We have wrapped several common plot types to make creating basic visualizations easily. These visualizations are powered by [Plotly](https://plot.ly/). 
+We have wrapped several common plot types to make creating basic visualizations easily. These visualizations are powered by [Plotly](https://plot.ly/).
 
 The following API is currently supported:
 - `vis.scatter`  : 2D or 3D scatter plots
@@ -165,7 +165,7 @@ Note that the server API adheres to the Plotly convention of `data` and `layout`
 import visdom
 vis = visdom.Visdom()
 
-trace = dict(x=[1,2,3], y=[4,5,6], marker={'color': 'red', 'symbol': 104, 'size': "10"}, 
+trace = dict(x=[1,2,3], y=[4,5,6], marker={'color': 'red', 'symbol': 104, 'size': "10"},
                     mode="markers+lines",  text=["one","two","three"], name='1st Trace')
 layout=dict(title="First Plot", xaxis={'title':'x1'}, yaxis={'title':'x2'})
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ vis:text{text = 'Hello, world!'}
 vis:image{img = image.fabio()}
 ```
 
+Some users have reported issues when connecting Lua clients to the Visdom server.
+A potential work-around may be to switch off IPv6:
+```
+vis = require 'visdom'()
+vis.ipv6 = false  -- switches off IPv6
+vis:text{text = 'Hello, world!'}
+```
 
 
 ### Demos

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ that contains the image.
 The following `options` are supported:
 
 - `options.jpgquality`: JPG quality (`number` 0-100; default = 100)
+- `options.caption`: Caption for the image
 
 #### vis.text
 This function prints text in a  box. You can use this to embed arbitrary HTML.

--- a/README.md
+++ b/README.md
@@ -284,16 +284,6 @@ The following `options` are supported:
 
 - `options.jpgquality`: JPG quality (`number` 0-100; default = 100)
 
-### plot.video
-This function plays a video. It takes as input the filename of the video
-`videofile` or a `LxCxHxW`-sized `tensor` (in Lua) or a or a `LxHxWxC`-sized
-`tensor` (in Python) containing all the frames of the video as input. The
-function does not support any plot-specific `options`.
-
-Note: Using `tensor` input requires that ffmpeg is installed and working.
-Your ability to play video may depend on the browser you use: your browser has
-to support the Theano codec in an OGG container (Chrome supports this).
-
 ### plot.svg
 This function draws an SVG object. It takes as input a SVG string `svgstr` or
 the name of an SVG file `svgfile`. The function does not support any specific

--- a/README.md
+++ b/README.md
@@ -270,12 +270,17 @@ The following `options` are supported:
 - `options.arrowheads`: show arrow heads (`boolean`; default = `true`)
 
 #### plot.image
-This function draws an img. It takes as input an `CxWxH` tensor `img`
+This function draws an `img`. It takes as input an `CxWxH` tensor `img`
 that contains the image.
 
 The following `options` are supported:
 
 - `options.jpgquality`: JPG quality (`number` 0-100; default = 100)
+
+### plot.svg
+This function draws an SVG object. It takes as input a SVG string `svgstr` or
+the name of an SVG file `svgfile`. The function does not support any specific
+`options`.
 
 #### plot.text
 This function prints text in a  box. It takes as input a `text` string.

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ The following `options` are supported:
 - `options.arrowheads`: show arrow heads (`boolean`; default = `true`)
 
 #### plot.image
-This function draws an `img`. It takes as input an `CxWxH` tensor `img`
+This function draws an `img`. It takes as input an `CxHxW` tensor `img`
 that contains the image.
 
 The following `options` are supported:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A flexible tool for creating, organizing, and sharing visualizations of live, ri
 * [Concepts](#concepts)
 * [Setup](#setup)
 * [Usage](#launch)
-* [Visualization API](#visualization-api)
+* [API](#api)
 * [To Do](#to-do)
 * [Contributing](#contributing)
 
@@ -130,10 +130,24 @@ th example/demo2.lua
 ```
 
 
-## Visualization API
-The following API is currently supported. Visualizations are powered by [Plotly](https://plot.ly/).
+## API
+For a quick introduction into the capabilities of `visdom`, have a look at the `example` directory, or read the details below.
+
+### Basics
+Visdom offers the following basic visualization functions:
+- `vis.image`    : images
+- `vis.text`     : arbitrary HTML
+- `vis.video`    : videos
+- `vis.svg`      : SVG object
+- `vis.save`     : serialize state server-side
+
+### Plotting
+We have wrapped several common plot types to make creating basic visualizations easily. These visualizations are powered by [Plotly](https://plot.ly/). 
+
+The following API is currently supported:
 - `vis.scatter`  : 2D or 3D scatter plots
 - `vis.line`     : line plots
+- `vis.updateTrace`     : update existing line/scatter plots
 - `vis.stem`     : stem plots
 - `vis.heatmap`  : heatmap plots
 - `vis.bar`      : bar graphs
@@ -142,18 +156,61 @@ The following API is currently supported. Visualizations are powered by [Plotly]
 - `vis.surf`     : surface plots
 - `vis.contour`  : contour plots
 - `vis.quiver`   : quiver plots
-- `vis.image`    : images
-- `vis.text`     : text box
 - `vis.mesh`     : mesh plots
-- `vis.save`     : serialize state
 
-Further details on each of these functions are given below. For a quick introduction into the capabilities of `visdom`, have a look at the `example` directory, or read the details below.
+#### Generic Plots
+Note that the server API adheres to the Plotly convention of `data` and `layout` objects, such that you can produce your own arbitrary `Plotly` visualizations:
 
-The exact inputs into the plotting functions vary, although most of them take as input a tensor `X` than contains the data and an (optional) tensor `Y` that contains optional data variables (such as labels or timestamps). All plotting functions take as input an optional `win` that can be used to plot into a specific window; each plotting function also returns the `win` of the window it plotted in. One can also specify the `env`  to which the visualization should be added.
+```python
+import visdom
+vis = visdom.Visdom()
+
+trace = dict(x=[1,2,3], y=[4,5,6], marker={'color': 'red', 'symbol': 104, 'size': "10"}, 
+                    mode="markers+lines",  text=["one","two","three"], name='1st Trace')
+layout=dict(title="First Plot", xaxis={'title':'x1'}, yaxis={'title':'x2'})
+
+vis._send(data=[trace], layout=layout, win='mywin')
+```
 
 ![visdom_big](https://lh3.googleusercontent.com/-bqH9UXCw-BE/WL2UsdrrbAI/AAAAAAAAnYc/emrxwCmnrW4_CLTyyUttB0SYRJ-i4CCiQCLcB/s0/Screen+Shot+2017-03-06+at+10.51.02+AM.png"visdom_big")
 
-#### plot.scatter
+
+## Details
+
+#### vis.image
+This function draws an `img`. It takes as input an `CxHxW` tensor `img`
+that contains the image.
+
+The following `options` are supported:
+
+- `options.jpgquality`: JPG quality (`number` 0-100; default = 100)
+
+#### vis.text
+This function prints text in a  box. You can use this to embed arbitrary HTML.
+It takes as input a `text` string.
+No specific `options` are currently supported.
+
+#### vis.video
+This function plays a video. It takes as input the filename of the video
+`videofile` or a `LxCxHxW`-sized `tensor` (in Lua) or a or a `LxHxWxC`-sized
+`tensor` (in Python) containing all the frames of the video as input. The
+function does not support any plot-specific `options`.
+
+Note: Using `tensor` input requires that ffmpeg is installed and working.
+Your ability to play video may depend on the browser you use: your browser has
+to support the Theano codec in an OGG container (Chrome supports this).
+
+#### vis.svg
+This function draws an SVG object. It takes as input a SVG string `svgstr` or
+the name of an SVG file `svgfile`. The function does not support any specific
+`options`.
+
+### Simple Plots
+Further details on the wrapped plotting functions are given below.
+
+The exact inputs into the plotting functions vary, although most of them take as input a tensor `X` than contains the data and an (optional) tensor `Y` that contains optional data variables (such as labels or timestamps). All plotting functions take as input an optional `win` that can be used to plot into a specific window; each plotting function also returns the `win` of the window it plotted in. One can also specify the `env`  to which the visualization should be added.
+
+#### vis.scatter
 This function draws a 2D or 3D scatter plot. It takes as input an `Nx2` or
 `Nx3` tensor `X` that specifies the locations of the `N` points in the
 scatter plot. An optional `N` tensor `Y` containing discrete labels that
@@ -174,7 +231,7 @@ The following `options` are supported:
 - Tensor of size `K` and `K x 3`: Instead of having a unique color per data point, the same color is shared for all points of a particular label.
 
 
-#### plot.line
+#### vis.line
 This function draws a line plot. It takes as input an `N` or `NxM` tensor
 `Y` that specifies the values of the `M` lines (that connect `N` points)
 to plot. It also takes an optional `X` tensor that specifies the
@@ -190,7 +247,26 @@ The following `options` are supported:
 - `options.markersize`  : marker size (`number`; default = `'10'`)
 - `options.legend`      : `table` containing legend names
 
-#### plot.stem
+
+#### vis.updateTrace
+This function allows updating of data for extant line or scatter plots.
+
+It is up to the user to specify `name` of an existing trace if they want
+to add to it, and a new `name` if they want to add a trace to the plot.
+By default, if no legend is specified at time of first creation,
+the `name` is the index of the line in the legend.
+
+If no `name` is specified, all traces should be updated.
+Trace update data that is all `NaN` is ignored;
+this can be used for masking update.
+
+The `append` parameter determines if the update data should be appended
+to or replaces existing data.
+
+There are no options because they are assumed to be inherited from the
+specified plot.
+
+#### vis.stem
 This function draws a stem plot. It takes as input an `N` or `NxM` tensor
 `X` that specifies the values of the `N` points in the `M` time series.
 An optional `N` or `NxM` tensor `Y` containing timestamps can be specified
@@ -202,7 +278,7 @@ The following `options` are supported:
 - `options.colormap`: colormap (`string`; default = `'Viridis'`)
 - `options.legend`  : `table` containing legend names
 
-#### plot.heatmap
+#### vis.heatmap
 This function draws a heatmap. It takes as input an `NxM` tensor `X` that
 specifies the value at each location in the heatmap.
 
@@ -214,7 +290,7 @@ The following `options` are supported:
 - `options.columnnames`: `table` containing x-axis labels
 - `options.rownames`   : `table` containing y-axis labels
 
-#### plot.bar
+#### vis.bar
 This function draws a regular, stacked, or grouped bar plot. It takes as
 input an `N` or `NxM` tensor `X` that specifies the height of each of the
 bars. If `X` contains `M` columns, the values corresponding to each row
@@ -228,7 +304,7 @@ The following plot-specific `options` are currently supported:
 - `options.stacked`    : stack multiple columns in `X`
 - `options.legend`     : `table` containing legend labels
 
-#### plot.histogram
+#### vis.histogram
 This function draws a histogram of the specified data. It takes as input
 an `N` tensor `X` that specifies the data of which to construct the
 histogram.
@@ -237,7 +313,7 @@ The following plot-specific `options` are currently supported:
 
 - `options.numbins`: number of bins (`number`; default = 30)
 
-#### plot.boxplot
+#### vis.boxplot
 This function draws boxplots of the specified data. It takes as input
 an `N` or an `NxM` tensor `X` that specifies the `N` data values of which
 to construct the `M` boxplots.
@@ -246,7 +322,7 @@ The following plot-specific `options` are currently supported:
 
 - `options.legend`: labels for each of the columns in `X`
 
-#### plot.surf
+#### vis.surf
 This function draws a surface plot. It takes as input an `NxM` tensor `X`
 that specifies the value at each location in the surface plot.
 
@@ -256,7 +332,7 @@ The following `options` are supported:
 - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
 
-#### plot.contour
+#### vis.contour
 This function draws a contour plot. It takes as input an `NxM` tensor `X`
 that specifies the value at each location in the contour plot.
 
@@ -266,7 +342,7 @@ The following `options` are supported:
 - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
 
-#### plot.quiver
+#### vis.quiver
 This function draws a quiver plot in which the direction and length of the
 arrows is determined by the `NxM` tensors `X` and `Y`. Two optional `NxM`
 tensors `gridX` and `gridY` can be provided that specify the offsets of
@@ -277,34 +353,7 @@ The following `options` are supported:
 - `options.normalize`:  length of longest arrows (`number`)
 - `options.arrowheads`: show arrow heads (`boolean`; default = `true`)
 
-#### plot.image
-This function draws an `img`. It takes as input an `CxHxW` tensor `img`
-that contains the image.
-
-The following `options` are supported:
-
-- `options.jpgquality`: JPG quality (`number` 0-100; default = 100)
-
-### plot.video
-This function plays a video. It takes as input the filename of the video
-`videofile` or a `LxCxHxW`-sized `tensor` (in Lua) or a or a `LxHxWxC`-sized
-`tensor` (in Python) containing all the frames of the video as input. The
-function does not support any plot-specific `options`.
-
-Note: Using `tensor` input requires that ffmpeg is installed and working.
-Your ability to play video may depend on the browser you use: your browser has
-to support the Theano codec in an OGG container (Chrome supports this).
-
-### plot.svg
-This function draws an SVG object. It takes as input a SVG string `svgstr` or
-the name of an SVG file `svgfile`. The function does not support any specific
-`options`.
-
-#### plot.text
-This function prints text in a  box. It takes as input a `text` string.
-No specific `options` are currently supported.
-
-### plot.mesh
+#### vis.mesh
 This function draws a mesh plot from a set of vertices defined in an
 `Nx2` or `Nx3` matrix `X`, and polygons defined in an optional `Mx2` or
 `Mx3` matrix `Y`.

--- a/example/demo.py
+++ b/example/demo.py
@@ -12,26 +12,11 @@ from __future__ import unicode_literals
 from visdom import Visdom
 import numpy as np
 import math
-import os.path
-import getpass
 
 viz = Visdom()
 
 textwindow = viz.text('Hello World!')
 
-# video demo:
-video = np.empty([256, 250, 250, 3], dtype=np.uint8)
-print(video.shape)
-for n in range(256):
-    video[n, :, :, :].fill(n)
-viz.video(tensor=video)
-
-# video demo: download video from http://media.w3.org/2010/05/sintel/trailer.ogv
-videofile = '/home/%s/trailer.ogv' % getpass.getuser()
-if os.path.isfile(videofile):
-    viz.video(videofile=videofile)
-
-# image demo
 viz.image(
     np.random.rand(3, 512, 256),
     opts=dict(title='Random!', caption='How random.'),

--- a/example/demo.py
+++ b/example/demo.py
@@ -12,11 +12,26 @@ from __future__ import unicode_literals
 from visdom import Visdom
 import numpy as np
 import math
+import os.path
+import getpass
 
 viz = Visdom()
 
 textwindow = viz.text('Hello World!')
 
+# video demo:
+video = np.empty([256, 250, 250, 3], dtype=np.uint8)
+print(video.shape)
+for n in range(256):
+    video[n, :, :, :].fill(n)
+viz.video(tensor=video)
+
+# video demo: download video from http://media.w3.org/2010/05/sintel/trailer.ogv
+videofile = '/home/%s/trailer.ogv' % getpass.getuser()
+if os.path.isfile(videofile):
+    viz.video(videofile=videofile)
+
+# image demo
 viz.image(
     np.random.rand(3, 512, 256),
     opts=dict(title='Random!', caption='How random.'),

--- a/example/demo.py
+++ b/example/demo.py
@@ -39,6 +39,12 @@ viz.image(
     opts=dict(title='Random!', caption='How random.'),
 )
 
+# grid of images
+viz.images(
+    np.random.randn(20, 3, 64, 64),
+    opts=dict(title='Random images', caption='How random.')
+)
+
 # scatter plots
 Y = np.random.rand(100)
 viz.scatter(

--- a/example/demo.py
+++ b/example/demo.py
@@ -12,11 +12,28 @@ from __future__ import unicode_literals
 from visdom import Visdom
 import numpy as np
 import math
+import os.path
+import getpass
 
 viz = Visdom()
 
 textwindow = viz.text('Hello World!')
 
+# video demo:
+try:
+    video = np.empty([256, 250, 250, 3], dtype=np.uint8)
+    for n in range(256):
+        video[n, :, :, :].fill(n)
+    viz.video(tensor=video)
+
+    # video demo: download video from http://media.w3.org/2010/05/sintel/trailer.ogv
+    videofile = '/home/%s/trailer.ogv' % getpass.getuser()
+    if os.path.isfile(videofile):
+        viz.video(videofile=videofile)
+except ImportError:
+    print('Skipped video example')
+
+# image demo
 viz.image(
     np.random.rand(3, 512, 256),
     opts=dict(title='Random!', caption='How random.'),

--- a/example/demo.py
+++ b/example/demo.py
@@ -220,6 +220,17 @@ viz.pie(
     opts=dict(legend=['Residential', 'Non-Residential', 'Utility'])
 )
 
+# mesh plot
+x = [0, 0, 1, 1, 0, 0, 1, 1]
+y = [0, 1, 1, 0, 0, 1, 1, 0]
+z = [0, 0, 0, 0, 1, 1, 1, 1]
+X = np.c_[x, y, z]
+i = [7, 0, 0, 0, 4, 4, 6, 6, 4, 0, 3, 2]
+j = [3, 4, 1, 2, 5, 6, 5, 2, 0, 1, 6, 3]
+k = [0, 7, 2, 3, 6, 7, 1, 1, 5, 5, 7, 6]
+Y = np.c_[i, j, k]
+viz.mesh(X=X, Y=Y, opts=dict(opacity=0.5))
+
 # SVG plotting
 svgstr = """
 <svg height="300" width="300">

--- a/example/demo.py
+++ b/example/demo.py
@@ -196,12 +196,24 @@ viz.stem(
     opts=dict(legend=['Sine', 'Cosine'])
 )
 
-
 # pie chart
 X = np.asarray([19, 26, 55])
 viz.pie(
     X=X,
     opts=dict(legend=['Residential', 'Non-Residential', 'Utility'])
+)
+
+# SVG plotting
+svgstr = """
+<svg height="300" width="300">
+  <ellipse cx="80" cy="80" rx="50" ry="30"
+   style="fill:red;stroke:purple;stroke-width:2" />
+  Sorry, your browser does not support inline SVG.
+</svg>
+"""
+viz.svg(
+    svgstr=svgstr,
+    opts=dict(title='Example of SVG Rendering')
 )
 
 # close text window:

--- a/example/demo.py
+++ b/example/demo.py
@@ -18,7 +18,7 @@ viz = Visdom()
 textwindow = viz.text('Hello World!')
 
 viz.image(
-    np.random.rand(512, 256, 3),
+    np.random.rand(3, 512, 256),
     opts=dict(title='Random!', caption='How random.'),
 )
 
@@ -218,3 +218,10 @@ viz.svg(
 
 # close text window:
 viz.close(win=textwindow)
+
+# PyTorch tensor
+try:
+    import torch
+    viz.line(Y=torch.Tensor([[0., 0.], [1., 1.]]))
+except ImportError:
+    print('Skipped PyTorch example')

--- a/example/demo1.lua
+++ b/example/demo1.lua
@@ -11,7 +11,6 @@ LICENSE file in the root directory of this source tree.
 -- dependencies:
 require 'torch'
 require 'image'
-local paths = require 'paths'
 
 -- intialize visdom Torch client:
 local visdom = require 'visdom'
@@ -19,20 +18,6 @@ local plot = visdom{server = 'http://localhost', port = 8097}
 
 -- text box demo:
 local textwindow = plot:text{text = 'Hello, world!'}
-
--- video demo:
-local video = torch.ByteTensor(256, 3, 128, 128)
-for n = 1,video:size(1) do
-   video[n]:fill(n - 1)
-end
-plot:video{tensor = video}
-
--- video demo:
-local videofile = '/home/' .. os.getenv('USER') .. '/trailer.ogv'
-   -- NOTE: Download video from http://media.w3.org/2010/05/sintel/trailer.ogv
-if paths.filep(videofile) then
-   plot:video{videofile = videofile}
-end
 
 -- image demo:
 plot:image{

--- a/example/demo1.lua
+++ b/example/demo1.lua
@@ -11,6 +11,7 @@ LICENSE file in the root directory of this source tree.
 -- dependencies:
 require 'torch'
 require 'image'
+local paths = require 'paths'
 
 -- intialize visdom Torch client:
 local visdom = require 'visdom'
@@ -251,6 +252,22 @@ plot:svg{
       title  = 'Example of SVG Rendering',
    },
 }
+
+-- video demo:
+local video = torch.ByteTensor(256, 3, 128, 128)
+for n = 1,video:size(1) do
+   video[n]:fill(n - 1)
+end
+local ok = pcall(plot.video, plot.video, {tensor = video})
+if not ok then print('Skipped video example') end
+
+-- video demo:
+local videofile = '/home/' .. os.getenv('USER') .. '/trailer.ogv'
+   -- NOTE: Download video from http://media.w3.org/2010/05/sintel/trailer.ogv
+if paths.filep(videofile) then
+   local ok = pcall(plot.video, plot.video, {videofile = videofile})
+   if not ok then print('Skipped video example') end
+end
 
 -- close text window:
 plot:close{win = textwindow}

--- a/example/demo1.lua
+++ b/example/demo1.lua
@@ -29,6 +29,22 @@ plot:image{
    }
 }
 
+-- images demo:
+plot:images{
+   table = {torch.zeros(3, 200, 200) + 0.1, torch.zeros(3, 200, 200) + 0.2},
+   options = {
+      caption = 'I was a table of tensors...',
+   }
+}
+
+-- images demo:
+plot:images{
+   tensor = torch.randn(6, 3, 200, 200),
+   options = {
+     caption = 'I was a 4D tensor...',
+   }
+}
+
 -- scatter plot demos:
 plot:scatter{
    X = torch.randn(100, 2),

--- a/example/demo1.lua
+++ b/example/demo1.lua
@@ -253,6 +253,19 @@ plot:svg{
    },
 }
 
+-- mesh plot demo:
+local X = torch.DoubleTensor{
+   {0, 0, 1, 1, 0, 0, 1, 1},
+   {0, 1, 1, 0, 0, 1, 1, 0},
+   {0, 0, 0, 0, 1, 1, 1, 1},
+}:t()
+local Y = torch.DoubleTensor{
+   {7, 0, 0, 0, 4, 4, 6, 6, 4, 0, 3, 2},
+   {3, 4, 1, 2, 5, 6, 5, 2, 0, 1, 6, 3},
+   {0, 7, 2, 3, 6, 7, 1, 1, 5, 5, 7, 6},
+}:t()
+plot:mesh{X = X, Y = Y, options = {opacity = 0.5}}
+
 -- video demo:
 local video = torch.ByteTensor(256, 3, 128, 128)
 for n = 1,video:size(1) do

--- a/example/demo1.lua
+++ b/example/demo1.lua
@@ -53,7 +53,7 @@ plot:scatter{
    },
 }
 
---2D scatterplot with custom intensities (red channel):
+-- 2D scatterplot with custom intensities (red channel):
 local id = plot:scatter{
     X = torch.randn(255, 2),
     options = {

--- a/example/demo1.lua
+++ b/example/demo1.lua
@@ -11,6 +11,7 @@ LICENSE file in the root directory of this source tree.
 -- dependencies:
 require 'torch'
 require 'image'
+local paths = require 'paths'
 
 -- intialize visdom Torch client:
 local visdom = require 'visdom'
@@ -18,6 +19,20 @@ local plot = visdom{server = 'http://localhost', port = 8097}
 
 -- text box demo:
 local textwindow = plot:text{text = 'Hello, world!'}
+
+-- video demo:
+local video = torch.ByteTensor(256, 3, 128, 128)
+for n = 1,video:size(1) do
+   video[n]:fill(n - 1)
+end
+plot:video{tensor = video}
+
+-- video demo:
+local videofile = '/home/' .. os.getenv('USER') .. '/trailer.ogv'
+   -- NOTE: Download video from http://media.w3.org/2010/05/sintel/trailer.ogv
+if paths.filep(videofile) then
+   plot:video{videofile = videofile}
+end
 
 -- image demo:
 plot:image{

--- a/example/demo1.lua
+++ b/example/demo1.lua
@@ -237,5 +237,20 @@ plot:pie{
    options = {legend = legend},
 }
 
+-- svg rendering demo:
+local svgstr = [[
+<svg height="300" width="300">
+  <ellipse cx="80" cy="80" rx="50" ry="30"
+   style="fill:red;stroke:purple;stroke-width:2" />
+  Sorry, your browser does not support inline SVG.
+</svg>
+]]
+plot:svg{
+   svgstr  = svgstr,
+   options = {
+      title  = 'Example of SVG Rendering',
+   },
+}
+
 -- close text window:
 plot:close{win = textwindow}

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -9,10 +9,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os.path
 import requests
 import traceback
 import json
 import math
+import re
 import numpy as np
 from PIL import Image
 import base64 as b64
@@ -226,6 +228,27 @@ class Visdom(object):
             'eid': env,
             'title': opts.get('title'),
         }))
+
+    def svg(self, svgstr=None, svgfile=None, win=None, env=None, opts=None):
+        """
+        This function draws an SVG object. It takes as input a SVG string or the
+        name of an SVG file. The function does not support any plot-specific
+        `options`.
+        """
+        opts = {} if opts is None else opts
+        _assert_opts(opts)
+
+        if svgfile is not None:
+            assert os.path.isfile(svgfile), 'could not find file %s' % svgfile
+            fileobj = open(svgfile, 'r')
+            assert fileobj, 'could not open file %s' % svgfile
+            svgstr = fileobj.read()
+            fileobj.close()
+
+        assert svgstr is not None, 'should specify SVG string or filename'
+        svg = re.search('<svg .+</svg>', svgstr, re.DOTALL)
+        assert svg is not None, 'could not parse SVG string'
+        return self.text(text=svg.group(0), win=win, env=env, opts=opts)
 
     def image(self, img, win=None, env=None, opts=None):
         """

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -364,8 +364,7 @@ class Visdom(object):
         nmaps = tensor.shape[0]
         xmaps = min(nrow, nmaps)
         ymaps = int(math.ceil(float(nmaps) / xmaps))
-        height, width = int(tensor.shape[2] + 2 * padding),
-        int(tensor.shape[3] + 2 * padding)
+        height, width = int(tensor.shape[2] + 2 * padding), int(tensor.shape[3] + 2 * padding)
 
         grid = np.ones([3, height * ymaps, width * xmaps])
         k = 0

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -45,7 +45,7 @@ def nan2none(l):
 
 def loadfile(filename):
     assert os.path.isfile(filename), 'could not find file %s' % filename
-    fileobj = open(filename, 'r')
+    fileobj = open(filename, 'rb')
     assert fileobj, 'could not open file %s' % filename
     str = fileobj.read()
     fileobj.close()
@@ -388,7 +388,7 @@ class Visdom(object):
                 <source type="video/%s" src="data:video/%s;base64,%s">
                 Your browser does not support the video tag.
             </video>
-        """ % (mimetype, mimetype, base64.b64encode(bytestr))
+        """ % (mimetype, mimetype, base64.b64encode(bytestr).decode('utf-8'))
         return self.text(text=videodata, win=win, env=env, opts=opts)
 
     def updateTrace(self, X, Y, win, env=None, name=None,

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -60,40 +60,40 @@ def _scrub_dict(d):
         return d
 
 
-def _axisformat(x, opts):
+def _axisformat(x, options):
     fields = ['type', 'tick', 'label', 'tickmin', 'tickmax']
     if any([x + i for i in fields]):
         return {
-            'type': opts.get(x + 'type'),
-            'title': opts.get(x + 'label'),
-            'range': [opts.get(x + 'tickmin'), opts.get(x + 'tickmax')]
-            if (opts.get(x + 'tickmin') and opts.get(x + 'tickmax')) else None,
-            'tickwidth': opts.get(x + 'tickstep'),
-            'showticklabels': opts.get(x + 'ytick'),
+            'type': options.get(x + 'type'),
+            'title': options.get(x + 'label'),
+            'range': [options.get(x + 'tickmin'), options.get(x + 'tickmax')]
+            if (options.get(x + 'tickmin') and options.get(x + 'tickmax')) else None,
+            'tickwidth': options.get(x + 'tickstep'),
+            'showticklabels': options.get(x + 'ytick'),
         }
 
 
-def _opts2layout(opts, is3d=False):
+def _options2layout(options, is3d=False):
     layout = {
-        'width': opts.get('width'),
-        'height': opts.get('height'),
-        'showlegend': opts.get('legend', False),
-        'title': opts.get('title'),
-        'xaxis': _axisformat('x', opts),
-        'yaxis': _axisformat('y', opts),
+        'width': options.get('width'),
+        'height': options.get('height'),
+        'showlegend': options.get('legend', False),
+        'title': options.get('title'),
+        'xaxis': _axisformat('x', options),
+        'yaxis': _axisformat('y', options),
         'margin': {
-            'l': opts.get('marginleft', 60),
-            'r': opts.get('marginright', 60),
-            't': opts.get('margintop', 60),
-            'b': opts.get('marginbottom', 60),
+            'l': options.get('marginleft', 60),
+            'r': options.get('marginright', 60),
+            't': options.get('margintop', 60),
+            'b': options.get('marginbottom', 60),
         }
     }
 
     if is3d:
-        layout['zaxis'] = _axisformat('z', opts)
+        layout['zaxis'] = _axisformat('z', options)
 
-    if opts.get('stacked'):
-        layout['barmode'] = 'stack' if opts.get('stacked') else 'group'
+    if options.get('stacked'):
+        layout['barmode'] = 'stack' if options.get('stacked') else 'group'
 
     return _scrub_dict(layout)
 
@@ -127,43 +127,43 @@ def _markerColorCheck(mc, X, Y, L):
     return ret
 
 
-def _assert_opts(opts):
-    if opts.get('color'):
-        assert isstr(opts.get('color')), 'color should be a string'
+def _assert_options(options):
+    if options.get('color'):
+        assert isstr(options.get('color')), 'color should be a string'
 
-    if opts.get('colormap'):
-        assert isstr(opts.get('colormap')), \
+    if options.get('colormap'):
+        assert isstr(options.get('colormap')), \
             'colormap should be string'
 
-    if opts.get('mode'):
-        assert isstr(opts.get('mode')), 'mode should be a string'
+    if options.get('mode'):
+        assert isstr(options.get('mode')), 'mode should be a string'
 
-    if opts.get('markersymbol'):
-        assert isstr(opts.get('markersymbol')), \
+    if options.get('markersymbol'):
+        assert isstr(options.get('markersymbol')), \
             'marker symbol should be string'
 
-    if opts.get('markersize'):
-        assert isnum(opts.get('markersize')) \
-            and opts.get('markersize') > 0, \
+    if options.get('markersize'):
+        assert isnum(options.get('markersize')) \
+            and options.get('markersize') > 0, \
             'marker size should be a positive number'
 
-    if opts.get('columnnames'):
-        assert isinstance(opts.get('columnnames'), list), \
+    if options.get('columnnames'):
+        assert isinstance(options.get('columnnames'), list), \
             'columnnames should be a table with column names'
 
-    if opts.get('rownames'):
-        assert isinstance(opts.get('rownames'), list), \
+    if options.get('rownames'):
+        assert isinstance(options.get('rownames'), list), \
             'rownames should be a table with row names'
 
-    if opts.get('jpgquality'):
-        assert isnum(opts.get('jpgquality')), \
+    if options.get('jpgquality'):
+        assert isnum(options.get('jpgquality')), \
             'JPG quality should be a number'
-        assert opts.get('jpgquality') > 0 and opts.get('jpgquality') <= 100, \
+        assert options.get('jpgquality') > 0 and options.get('jpgquality') <= 100, \
             'JPG quality should be number between 0 and 100'
 
-    if opts.get('opacity'):
-        assert isnum(opts.get('opacity')), 'opacity should be a number'
-        assert 0 <= opts.get('opacity') <= 1, \
+    if options.get('opacity'):
+        assert isnum(options.get('opacity')), 'opacity should be a number'
+        assert 0 <= options.get('opacity') <= 1, \
             'opacity should be a number between 0 and 1'
 
 
@@ -261,30 +261,30 @@ class Visdom(object):
 
     # Content
 
-    def text(self, text, win=None, env=None, opts=None):
+    def text(self, text, win=None, env=None, options=None):
         """
         This function prints text in a box. It takes as input an `text` string.
-        No specific `opts` are currently supported.
+        No specific `options` are currently supported.
         """
-        opts = {} if opts is None else opts
-        _assert_opts(opts)
+        options = {} if options is None else options
+        _assert_options(options)
         data = [{'content': text, 'type': 'text'}]
 
         return self._send({
             'data': data,
             'win': win,
             'eid': env,
-            'title': opts.get('title'),
+            'title': options.get('title'),
         })
 
-    def svg(self, svgstr=None, svgfile=None, win=None, env=None, opts=None):
+    def svg(self, svgstr=None, svgfile=None, win=None, env=None, options=None):
         """
         This function draws an SVG object. It takes as input an SVG string or the
         name of an SVG file. The function does not support any plot-specific
         `options`.
         """
-        opts = {} if opts is None else opts
-        _assert_opts(opts)
+        options = {} if options is None else options
+        _assert_options(options)
 
         if svgfile is not None:
             svgstr = loadfile(svgfile)
@@ -292,17 +292,17 @@ class Visdom(object):
         assert svgstr is not None, 'should specify SVG string or filename'
         svg = re.search('<svg .+</svg>', svgstr, re.DOTALL)
         assert svg is not None, 'could not parse SVG string'
-        return self.text(text=svg.group(0), win=win, env=env, opts=opts)
+        return self.text(text=svg.group(0), win=win, env=env, options=options)
 
-    def image(self, img, win=None, env=None, opts=None):
+    def image(self, img, win=None, env=None, options=None):
         """
         This function draws an img. It takes as input an `CxHxW` tensor `img`
         that contains the image. The array values can be float in [0,1] or uint8
         in [0, 255].
         """
-        opts = {} if opts is None else opts
-        opts['jpgquality'] = opts.get('jpgquality', 75)
-        _assert_opts(opts)
+        options = {} if options is None else options
+        options['jpgquality'] = options.get('jpgquality', 75)
+        _assert_options(options)
 
         nchannels = img.shape[0] if img.ndim == 3 else 1
         if nchannels == 1:
@@ -316,14 +316,14 @@ class Visdom(object):
         img = np.transpose(img, (1, 2, 0))
         im = Image.fromarray(img)
         buf = BytesIO()
-        im.save(buf, format='JPEG', quality=opts['jpgquality'])
+        im.save(buf, format='JPEG', quality=options['jpgquality'])
         b64encoded = b64.b64encode(buf.getvalue()).decode('utf-8')
 
         data = [{
             'content': {
                 'src': 'data:image/jpg;base64,' + b64encoded,
-                'caption': opts.get('caption'),
-                'size': opts.get('size', list(img.shape)),
+                'caption': options.get('caption'),
+                'size': options.get('size', list(img.shape)),
             },
             'type': 'image',
         }]
@@ -332,11 +332,11 @@ class Visdom(object):
             'data': data,
             'win': win,
             'eid': env,
-            'title': opts.get('title'),
+            'title': options.get('title'),
         })
 
     def images(self, tensor, nrow=8, padding=2,
-               win=None, env=None, opts=None):
+               win=None, env=None, options=None):
         """
         Given a 4D tensor of shape (B x C x H x W),
         or a list of images all of the same size,
@@ -356,7 +356,7 @@ class Visdom(object):
         if tensor.ndim == 3:  # single image
             if tensor.shape[0] == 1:  # if single-channel, convert to 3-channel
                 tensor = np.repeat(tensor, 3, 0)
-            return self.image(tensor, win, env, opts)
+            return self.image(tensor, win, env, options)
         if tensor.ndim == 4 and tensor.shape[1] == 1:  # single-channel images
             tensor = np.repeat(tensor, 3, 1)
 
@@ -379,16 +379,16 @@ class Visdom(object):
                 grid[:, h_start:h_end, w_start:w_end] = tensor[k]
                 k += 1
 
-        return self.image(grid, win, env, opts)
+        return self.image(grid, win, env, options)
 
-    def video(self, tensor=None, videofile=None, win=None, env=None, opts=None):
+    def video(self, tensor=None, videofile=None, win=None, env=None, options=None):
         """
         This function plays a video. It takes as input the filename of the video
         or a `LxCxHxW` tensor containing all the frames of the video. The function
         does not support any plot-specific `options`.
         """
-        opts = {} if opts is None else opts
-        _assert_opts(opts)
+        options = {} if options is None else options
+        _assert_options(options)
         assert tensor is not None or videofile is not None, \
             'should specify video tensor or file'
 
@@ -435,10 +435,10 @@ class Visdom(object):
                 Your browser does not support the video tag.
             </video>
         """ % (mimetype, mimetype, base64.b64encode(bytestr).decode('utf-8'))
-        return self.text(text=videodata, win=win, env=env, opts=opts)
+        return self.text(text=videodata, win=win, env=env, options=options)
 
     def updateTrace(self, X, Y, win, env=None, name=None,
-                    append=True, opts=None):
+                    append=True, options=None):
         """
         This function allows updating of the data of a line or scatter plot.
 
@@ -481,7 +481,7 @@ class Visdom(object):
             'append': append,
         }, endpoint='update')
 
-    def scatter(self, X, Y=None, win=None, env=None, opts=None, update=None):
+    def scatter(self, X, Y=None, win=None, env=None, options=None, update=None):
         """
         This function draws a 2D or 3D scatter plot. It takes in an `Nx2` or
         `Nx3` tensor `X` that specifies the locations of the `N` points in the
@@ -493,17 +493,17 @@ class Visdom(object):
         Use 'append' to append data, 'replace' to use new data.
         Update data that is all NaN is ignored (can be used for masking update).
 
-        The following `opts` are supported:
+        The following `options` are supported:
 
-        - `opts.colormap`    : colormap (`string`; default = `'Viridis'`)
-        - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
-        - `opts.markersize`  : marker size (`number`; default = `'10'`)
-        - `opts.markercolor` : marker color (`np.array`; default = `None`)
-        - `opts.legend`      : `table` containing legend names
+        - `options.colormap`    : colormap (`string`; default = `'Viridis'`)
+        - `options.markersymbol`: marker symbol (`string`; default = `'dot'`)
+        - `options.markersize`  : marker size (`number`; default = `'10'`)
+        - `options.markercolor` : marker color (`np.array`; default = `None`)
+        - `options.legend`      : `table` containing legend names
         """
         if update is not None:
             return self.updateTrace(X=X, Y=Y, win=win, env=env,
-                                    append=update == 'append', opts=opts)
+                                    append=update == 'append', options=options)
 
         assert X.ndim == 2, 'X should have two dims'
         assert X.shape[1] == 2 or X.shape[1] == 3, 'X should have 2 or 3 cols'
@@ -521,36 +521,36 @@ class Visdom(object):
         K = int(Y.max())
         is3d = X.shape[1] == 3
 
-        opts = {} if opts is None else opts
-        opts['colormap'] = opts.get('colormap', 'Viridis')
-        opts['mode'] = opts.get('mode', 'markers')
-        opts['markersymbol'] = opts.get('markersymbol', 'dot')
-        opts['markersize'] = opts.get('markersize', 10)
+        options = {} if options is None else options
+        options['colormap'] = options.get('colormap', 'Viridis')
+        options['mode'] = options.get('mode', 'markers')
+        options['markersymbol'] = options.get('markersymbol', 'dot')
+        options['markersize'] = options.get('markersize', 10)
 
-        if opts.get('markercolor') is not None:
-            opts['markercolor'] = _markerColorCheck(
-                opts['markercolor'], X, Y, K)
+        if options.get('markercolor') is not None:
+            options['markercolor'] = _markerColorCheck(
+                options['markercolor'], X, Y, K)
 
-        _assert_opts(opts)
+        _assert_options(options)
 
-        if opts.get('legend'):
-            assert type(opts['legend']) == list and len(opts['legend']) == K
+        if options.get('legend'):
+            assert type(options['legend']) == list and len(options['legend']) == K
 
         data = []
         for k in range(1, K + 1):
             ind = np.equal(Y, k)
             if ind.any():
-                mc = opts.get('markercolor')
+                mc = options.get('markercolor')
                 _data = {
                     'x': nan2none(X.take(0, 1)[ind].tolist()),
                     'y': nan2none(X.take(1, 1)[ind].tolist()),
-                    'name': opts.get('legend') and
-                    opts.get('legend')[k - 1] or str(k),
+                    'name': options.get('legend') and
+                    options.get('legend')[k - 1] or str(k),
                     'type': 'scatter3d' if is3d else 'scatter',
-                    'mode': opts.get('mode'),
+                    'mode': options.get('mode'),
                     'marker': {
-                        'size': opts.get('markersize'),
-                        'symbol': opts.get('markersymbol'),
+                        'size': options.get('markersize'),
+                        'symbol': options.get('markersymbol'),
                         'color': mc[k] if mc is not None else None,
                         'line': {
                             'color': '#000000',
@@ -558,7 +558,7 @@ class Visdom(object):
                         }
                     }
                 }
-                if opts.get('fillarea'):
+                if options.get('fillarea'):
                     _data['fill'] = 'tonexty'
 
                 if is3d:
@@ -570,10 +570,10 @@ class Visdom(object):
             'data': data,
             'win': win,
             'eid': env,
-            'layout': _opts2layout(opts, is3d),
+            'layout': _options2layout(options, is3d),
         })
 
-    def line(self, Y, X=None, win=None, env=None, opts=None, update=None):
+    def line(self, Y, X=None, win=None, env=None, options=None, update=None):
         """
         This function draws a line plot. It takes in an `N` or `NxM` tensor
         `Y` that specifies the values of the `M` lines (that connect `N` points)
@@ -585,14 +585,14 @@ class Visdom(object):
         Use 'append' to append data, 'replace' to use new data.
         Update data that is all NaN is ignored (can be used for masking update).
 
-        The following `opts` are supported:
+        The following `options` are supported:
 
-        - `opts.fillarea`    : fill area below line (`boolean`)
-        - `opts.colormap`    : colormap (`string`; default = `'Viridis'`)
-        - `opts.markers`     : show markers (`boolean`; default = `false`)
-        - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
-        - `opts.markersize`  : marker size (`number`; default = `'10'`)
-        - `opts.legend`      : `table` containing legend names
+        - `options.fillarea`    : fill area below line (`boolean`)
+        - `options.colormap`    : colormap (`string`; default = `'Viridis'`)
+        - `options.markers`     : show markers (`boolean`; default = `false`)
+        - `options.markersymbol`: marker symbol (`string`; default = `'dot'`)
+        - `options.markersize`  : marker size (`number`; default = `'10'`)
+        - `options.legend`      : `table` containing legend names
 
         If `update` is specified, the figure will be updated without
         creating a new plot -- this can be used for efficient updating.
@@ -600,7 +600,7 @@ class Visdom(object):
         if update is not None:
             assert X is not None, 'must specify x-values for line update'
             return self.updateTrace(X=X, Y=Y, win=win, env=env,
-                                    append=update == 'append', opts=opts)
+                                    append=update == 'append', options=options)
         assert Y.ndim == 1 or Y.ndim == 2, 'Y should have 1 or 2 dim'
 
         if X is not None:
@@ -613,12 +613,12 @@ class Visdom(object):
 
         assert X.shape == Y.shape, 'X and Y should be the same shape'
 
-        opts = {} if opts is None else opts
-        opts['markers'] = opts.get('markers', False)
-        opts['fillarea'] = opts.get('fillarea', False)
-        opts['mode'] = 'lines+markers' if opts.get('markers') else 'lines'
+        options = {} if options is None else options
+        options['markers'] = options.get('markers', False)
+        options['fillarea'] = options.get('fillarea', False)
+        options['mode'] = 'lines+markers' if options.get('markers') else 'lines'
 
-        _assert_opts(opts)
+        _assert_options(options)
 
         if Y.ndim == 1:
             linedata = np.column_stack((X, Y))
@@ -630,68 +630,68 @@ class Visdom(object):
             labels = np.arange(1, Y.shape[1] + 1)
             labels = np.tile(labels, (Y.shape[0], 1)).ravel(order='F')
 
-        return self.scatter(X=linedata, Y=labels, opts=opts, win=win, env=env)
+        return self.scatter(X=linedata, Y=labels, options=options, win=win, env=env)
 
-    def heatmap(self, X, win=None, env=None, opts=None):
+    def heatmap(self, X, win=None, env=None, options=None):
         """
         This function draws a heatmap. It takes as input an `NxM` tensor `X`
         that specifies the value at each location in the heatmap.
 
-        The following `opts` are supported:
+        The following `options` are supported:
 
-        - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
-        - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
-        - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
-        - `opts.columnnames`: `table` containing x-axis labels
-        - `opts.rownames`: `table` containing y-axis labels
+        - `options.colormap`: colormap (`string`; default = `'Viridis'`)
+        - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
+        - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
+        - `options.columnnames`: `table` containing x-axis labels
+        - `options.rownames`: `table` containing y-axis labels
         """
 
         assert X.ndim == 2, 'data should be two-dimensional'
-        opts = {} if opts is None else opts
-        opts['xmin'] = opts.get('xmin', np.asscalar(X.min()))
-        opts['xmax'] = opts.get('xmax', np.asscalar(X.max()))
-        opts['colormap'] = opts.get('colormap', 'Viridis')
-        _assert_opts(opts)
+        options = {} if options is None else options
+        options['xmin'] = options.get('xmin', np.asscalar(X.min()))
+        options['xmax'] = options.get('xmax', np.asscalar(X.max()))
+        options['colormap'] = options.get('colormap', 'Viridis')
+        _assert_options(options)
 
-        if opts.get('columnnames') is not None:
-            assert len(opts['columnnames']) == X.shape[1], \
+        if options.get('columnnames') is not None:
+            assert len(options['columnnames']) == X.shape[1], \
                 'number of column names should match number of columns in X'
 
-        if opts.get('rownames') is not None:
-            assert len(opts['rownames']) == X.shape[0], \
+        if options.get('rownames') is not None:
+            assert len(options['rownames']) == X.shape[0], \
                 'number of row names should match number of rows in X'
 
         data = [{
             'z': X.tolist(),
-            'x': opts.get('columnnames'),
-            'y': opts.get('rownames'),
-            'zmin': opts.get('xmin'),
-            'zmax': opts.get('xmax'),
+            'x': options.get('columnnames'),
+            'y': options.get('rownames'),
+            'zmin': options.get('xmin'),
+            'zmax': options.get('xmax'),
             'type': 'heatmap',
-            'colorscale': opts.get('colormap'),
+            'colorscale': options.get('colormap'),
         }]
 
         return self._send({
             'data': data,
             'win': win,
             'eid': env,
-            'layout': _opts2layout(opts)
+            'layout': _options2layout(options)
         })
 
-    def bar(self, X, Y=None, win=None, env=None, opts=None):
+    def bar(self, X, Y=None, win=None, env=None, options=None):
         """
         This function draws a regular, stacked, or grouped bar plot. It takes as
         input an `N` or `NxM` tensor `X` that specifies the height of each
         bar. If `X` contains `M` columns, the values corresponding to each row
-        are either stacked or grouped (dependending on how `opts.stacked` is
+        are either stacked or grouped (dependending on how `options.stacked` is
         set). In addition to `X`, an (optional) `N` tensor `Y` can be specified
         that contains the corresponding x-axis values.
 
-        The following plot-specific `opts` are currently supported:
+        The following plot-specific `options` are currently supported:
 
-        - `opts.rownames`: `table` containing x-axis labels
-        - `opts.stacked` : stack multiple columns in `X`
-        - `opts.legend`  : `table` containing legend labels
+        - `options.rownames`: `table` containing x-axis labels
+        - `options.stacked` : stack multiple columns in `X`
+        - `options.legend`  : `table` containing legend labels
         """
         X = np.squeeze(X)
         assert X.ndim == 1 or X.ndim == 2, 'X should be one or two-dimensional'
@@ -704,75 +704,75 @@ class Visdom(object):
         else:
             Y = np.arange(1, len(X) + 1)
 
-        opts = {} if opts is None else opts
-        opts['stacked'] = opts.get('stacked', False)
+        options = {} if options is None else options
+        options['stacked'] = options.get('stacked', False)
 
-        _assert_opts(opts)
+        _assert_options(options)
 
-        if opts.get('rownames') is not None:
-            assert len(opts['rownames']) == X.shape[0], \
+        if options.get('rownames') is not None:
+            assert len(options['rownames']) == X.shape[0], \
                 'number of row names should match number of rows in X'
 
-        if opts.get('legend') is not None:
-            assert len(opts['legend']) == X.shape[1], \
+        if options.get('legend') is not None:
+            assert len(options['legend']) == X.shape[1], \
                 'number of legened labels must match number of columns in X'
 
         data = []
         for k in range(X.shape[1]):
             _data = {
                 'y': X.take(k, 1).tolist(),
-                'x': opts.get('rownames', Y.tolist()),
+                'x': options.get('rownames', Y.tolist()),
                 'type': 'bar',
             }
-            if opts.get('legend'):
-                _data['name'] = opts['legend'][k]
+            if options.get('legend'):
+                _data['name'] = options['legend'][k]
             data.append(_data)
 
         return self._send({
             'data': data,
             'win': win,
             'eid': env,
-            'layout': _opts2layout(opts)
+            'layout': _options2layout(options)
         })
 
-    def histogram(self, X, win=None, env=None, opts=None):
+    def histogram(self, X, win=None, env=None, options=None):
         """
         This function draws a histogram of the specified data. It takes as input
         an `N` tensor `X` that specifies the data of which to construct the
         histogram.
 
-        The following plot-specific `opts` are currently supported:
+        The following plot-specific `options` are currently supported:
 
-        - `opts.numbins`: number of bins (`number`; default = 30)
+        - `options.numbins`: number of bins (`number`; default = 30)
         """
 
         X = np.squeeze(X)
         assert X.ndim == 1, 'X should be one-dimensional'
 
-        opts = {} if opts is None else opts
-        opts['numbins'] = opts.get('numbins', min(30, len(X)))
-        _assert_opts(opts)
+        options = {} if options is None else options
+        options['numbins'] = options.get('numbins', min(30, len(X)))
+        _assert_options(options)
 
         minx, maxx = X.min(), X.max()
-        bins = np.histogram(X, bins=opts['numbins'], range=(minx, maxx))[0]
-        linrange = np.linspace(minx, maxx, opts['numbins'])
+        bins = np.histogram(X, bins=options['numbins'], range=(minx, maxx))[0]
+        linrange = np.linspace(minx, maxx, options['numbins'])
 
         return self.bar(
             X=bins,
             Y=linrange,
-            opts=opts,
+            options=options,
             win=win,
             env=env
         )
 
-    def boxplot(self, X, win=None, env=None, opts=None):
+    def boxplot(self, X, win=None, env=None, options=None):
         """
         This function draws boxplots of the specified data. It takes as input
         an `N` or an `NxM` tensor `X` that specifies the `N` data values of
         which to construct the `M` boxplots.
 
-        The following plot-specific `opts` are currently supported:
-        - `opts.legend`: labels for each of the columns in `X`
+        The following plot-specific `options` are currently supported:
+        - `options.legend`: labels for each of the columns in `X`
         """
 
         X = np.squeeze(X)
@@ -780,11 +780,11 @@ class Visdom(object):
         if X.ndim == 1:
             X = X[:, None]
 
-        opts = {} if opts is None else opts
-        _assert_opts(opts)
+        options = {} if options is None else options
+        _assert_options(options)
 
-        if opts.get('legend') is not None:
-            assert len(opts['legend']) == X.shape[1], \
+        if options.get('legend') is not None:
+            assert len(options['legend']) == X.shape[1], \
                 'number of legened labels must match number of columns'
 
         data = []
@@ -793,8 +793,8 @@ class Visdom(object):
                 'y': X.take(k, 1).tolist(),
                 'type': 'box',
             }
-            if opts.get('legend'):
-                _data['name'] = opts['legend'][k]
+            if options.get('legend'):
+                _data['name'] = options['legend'][k]
             else:
                 _data['name'] = 'column ' + str(k)
 
@@ -804,79 +804,79 @@ class Visdom(object):
             'data': data,
             'win': win,
             'eid': env,
-            'layout': _opts2layout(opts)
+            'layout': _options2layout(options)
         })
 
-    def _surface(self, X, stype, win=None, env=None, opts=None):
+    def _surface(self, X, stype, win=None, env=None, options=None):
         """
         This function draws a surface plot. It takes as input an `NxM` tensor
         `X` that specifies the value at each location in the surface plot.
 
         `stype` is 'contour' (2D) or 'surf' (3D).
 
-        The following `opts` are supported:
+        The following `options` are supported:
 
-        - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
-        - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
-        - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
+        - `options.colormap`: colormap (`string`; default = `'Viridis'`)
+        - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
+        - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
         """
 
         X = np.squeeze(X)
         assert X.ndim == 2, 'X should be two-dimensional'
 
-        opts = {} if opts is None else opts
-        opts['xmin'] = opts.get('xmin', X.min())
-        opts['xmax'] = opts.get('xmax', X.max())
-        opts['colormap'] = opts.get('colormap', 'Viridis')
-        _assert_opts(opts)
+        options = {} if options is None else options
+        options['xmin'] = options.get('xmin', X.min())
+        options['xmax'] = options.get('xmax', X.max())
+        options['colormap'] = options.get('colormap', 'Viridis')
+        _assert_options(options)
 
         data = [{
             'z': X.tolist(),
-            'cmin': opts['xmin'],
-            'cmax': opts['xmax'],
+            'cmin': options['xmin'],
+            'cmax': options['xmax'],
             'type': stype,
-            'colorscale': opts['colormap']
+            'colorscale': options['colormap']
         }]
 
         return self._send({
             'data': data,
             'win': win,
             'eid': env,
-            'layout': _opts2layout(
-                opts, is3d=True if stype == 'surface' else False)
+            'layout': _options2layout(
+                options, is3d=True if stype == 'surface' else False)
         })
 
-    def surf(self, X, win=None, env=None, opts=None):
+    def surf(self, X, win=None, env=None, options=None):
         """
         This function draws a surface plot. It takes as input an `NxM` tensor
         `X` that specifies the value at each location in the surface plot.
 
         `stype` is 'contour' (2D) or 'surf' (3D).
 
-        The following `opts` are supported:
+        The following `options` are supported:
 
-        - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
-        - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
-        - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
+        - `options.colormap`: colormap (`string`; default = `'Viridis'`)
+        - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
+        - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
         """
 
-        self._surface(X=X, stype='surface', opts=opts, win=win, env=env)
+        self._surface(X=X, stype='surface', options=options, win=win, env=env)
 
-    def contour(self, X, win=None, env=None, opts=None):
+    def contour(self, X, win=None, env=None, options=None):
         """
         This function draws a contour plot. It takes as input an `NxM` tensor
         `X` that specifies the value at each location in the contour plot.
 
-        The following `opts` are supported:
+        The following `options` are supported:
 
-        - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
-        - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
-        - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
+        - `options.colormap`: colormap (`string`; default = `'Viridis'`)
+        - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
+        - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
         """
 
-        self._surface(X=X, stype='contour', opts=opts, win=win, env=env)
+        self._surface(X=X, stype='contour', options=options, win=win, env=env)
 
-    def stem(self, X, Y=None, win=None, env=None, opts=None):
+    def stem(self, X, Y=None, win=None, env=None, options=None):
         """
         This function draws a stem plot. It takes as input an `N` or `NxM`tensor
         `X` that specifies the values of the `N` points in the `M` time series.
@@ -884,10 +884,10 @@ class Visdom(object):
         as well; if `Y` is an `N` tensor then all `M` time series are assumed to
         have the same timestamps.
 
-        The following `opts` are supported:
+        The following `options` are supported:
 
-        - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
-        - `opts.legend`  : `table` containing legend names
+        - `options.colormap`: colormap (`string`; default = `'Viridis'`)
+        - `options.legend`  : `table` containing legend names
         """
 
         X = np.squeeze(X)
@@ -916,13 +916,13 @@ class Visdom(object):
         labels = np.arange(1, X.shape[1] + 1)[None, :]
         labels = np.tile(labels, (X.shape[0], 1)).flatten()
 
-        opts = {} if opts is None else opts
-        opts['mode'] = 'lines'
-        _assert_opts(opts)
+        options = {} if options is None else options
+        options['mode'] = 'lines'
+        _assert_options(options)
 
-        return self.scatter(X=data, Y=labels, opts=opts, win=win, env=env)
+        return self.scatter(X=data, Y=labels, options=options, win=win, env=env)
 
-    def pie(self, X, win=None, env=None, opts=None):
+    def pie(self, X, win=None, env=None, options=None):
         """
         This function draws a pie chart based on the `N` tensor `X`.
 
@@ -936,22 +936,22 @@ class Visdom(object):
         assert np.all(np.greater_equal(X, 0)), \
             'X cannot contain negative values'
 
-        opts = {} if opts is None else opts
-        _assert_opts(opts)
+        options = {} if options is None else options
+        _assert_options(options)
 
         data = [{
             'values': X.tolist(),
-            'labels': opts.get('legend'),
+            'labels': options.get('legend'),
             'type': 'pie',
         }]
         return self._send({
             'data': data,
             'win': win,
             'eid': env,
-            'layout': _opts2layout(opts)
+            'layout': _options2layout(options)
         })
 
-    def mesh(self, X, Y=None, win=None, env=None, opts=None):
+    def mesh(self, X, Y=None, win=None, env=None, options=None):
         """
         This function draws a mesh plot from a set of vertices defined in an
         `Nx2` or `Nx3` matrix `X`, and polygons defined in an optional `Mx2` or
@@ -962,8 +962,8 @@ class Visdom(object):
         - `options.color`: color (`string`)
         - `options.opacity`: opacity of polygons (`number` between 0 and 1)
         """
-        opts = {} if opts is None else opts
-        _assert_opts(opts)
+        options = {} if options is None else options
+        _assert_options(options)
 
         X = np.asarray(X)
         assert X.ndim == 2, 'X must have 2 dimensions'
@@ -984,13 +984,13 @@ class Visdom(object):
             'i': Y[:, 0].tolist() if ispoly else None,
             'j': Y[:, 1].tolist() if ispoly else None,
             'k': Y[:, 2].tolist() if is3d and ispoly else None,
-            'color': opts.get('color'),
-            'opacity': opts.get('opacity'),
+            'color': options.get('color'),
+            'opacity': options.get('opacity'),
             'type': 'mesh3d' if is3d else 'mesh',
         }]
         return self._send({
             'data': data,
             'win': win,
             'eid': env,
-            'layout': _opts2layout(opts)
+            'layout': _options2layout(options)
         })

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -201,7 +201,7 @@ class Visdom(object):
         build the required JSON yourself. `endpoint` specifies the destination
         Tornado server endpoint for the request.
         """
-        if 'eid' not in msg:
+        if msg.get('eid', None) is None:
             msg['eid'] = self.env
 
         try:

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -306,7 +306,7 @@ class Visdom(object):
 
         nchannels = img.shape[0] if img.ndim == 3 else 1
         if nchannels == 1:
-            img = img[:, :, np.newaxis].repeat(3, axis=2)
+            img = img[np.newaxis, :, :].repeat(3, axis=0)
 
         if 'float' in str(img.dtype):
             if img.max() <= 1:

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -15,7 +15,6 @@ import traceback
 import json
 import math
 import re
-import base64
 import numpy as np
 from PIL import Image
 import base64 as b64
@@ -41,15 +40,6 @@ def nan2none(l):
         if math.isnan(val):
             l[idx] = None
     return l
-
-
-def loadfile(filename):
-    assert os.path.isfile(filename), 'could not find file %s' % filename
-    fileobj = open(filename, 'r')
-    assert fileobj, 'could not open file %s' % filename
-    str = fileobj.read()
-    fileobj.close()
-    return str
 
 
 def _scrub_dict(d):
@@ -279,7 +269,11 @@ class Visdom(object):
         _assert_opts(opts)
 
         if svgfile is not None:
-            svgstr = loadfile(svgfile)
+            assert os.path.isfile(svgfile), 'could not find file %s' % svgfile
+            fileobj = open(svgfile, 'r')
+            assert fileobj, 'could not open file %s' % svgfile
+            svgstr = fileobj.read()
+            fileobj.close()
 
         assert svgstr is not None, 'should specify SVG string or filename'
         svg = re.search('<svg .+</svg>', svgstr, re.DOTALL)
@@ -326,54 +320,6 @@ class Visdom(object):
             'eid': env,
             'title': opts.get('title'),
         })
-
-    def video(self, tensor=None, videofile=None, win=None, env=None, opts=None):
-        """
-        This function plays a video. It takes as input the filename of the video
-        or a `LxCxHxW` tensor containing all the frames of the video. The function
-        does not support any plot-specific `options`.
-        """
-        opts = {} if opts is None else opts
-        _assert_opts(opts)
-        assert tensor is not None or videofile is not None, \
-            'should specify video tensor or file'
-
-        if tensor is not None:
-            import cv2
-            import tempfile
-            assert tensor.ndim == 4, 'video should be in 4D tensor'
-            videofile = '/tmp/%s.ogv' % next(tempfile._get_candidate_names())
-            fourcc = cv2.cv.CV_FOURCC(
-                chr(ord('T')),
-                chr(ord('H')),
-                chr(ord('E')),
-                chr(ord('O'))
-            )
-            writer = cv2.VideoWriter(
-                videofile,
-                fourcc,
-                25,
-                (tensor.shape[1], tensor.shape[2])
-            )
-            assert writer.isOpened(), 'video writer could not be opened'
-            for i in range(tensor.shape[0]):
-                writer.write(tensor[i, :, :, :])
-            writer.release()
-            writer = None
-
-        extension = videofile[-3:].lower()
-        mimetypes = dict(mp4='mp4', ogv='ogg', avi='avi', webm='webm')
-        mimetype = mimetypes.get(extension)
-        assert mimetype is not None, 'unknown video type: %s' % extension
-
-        bytestr = loadfile(videofile)
-        videodata = """
-            <video controls>
-                <source type="video/%s" src="data:video/%s;base64,%s">
-                Your browser does not support the video tag.
-            </video>
-        """ % (mimetype, mimetype, base64.b64encode(bytestr))
-        return self.text(text=videodata, win=win, env=env, opts=opts)
 
     def updateTrace(self, X, Y, win, env=None, name=None,
                     append=True, opts=None):

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -485,11 +485,9 @@ class Visdom(object):
             assert X is not None, 'must specify x-values for line update'
             return self.updateTrace(X=X, Y=Y, win=win, env=env,
                                     append=update == 'append', opts=opts)
-        Y = np.squeeze(Y)
         assert Y.ndim == 1 or Y.ndim == 2, 'Y should have 1 or 2 dim'
 
         if X is not None:
-            X = np.squeeze(X)
             assert X.ndim == 1 or X.ndim == 2, 'X should have 1 or 2 dim'
         else:
             X = np.linspace(0, 1, Y.shape[0])

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -351,12 +351,20 @@ class Visdom(object):
             import tempfile
             assert tensor.ndim == 4, 'video should be in 4D tensor'
             videofile = '/tmp/%s.ogv' % next(tempfile._get_candidate_names())
-            fourcc = cv2.cv.CV_FOURCC(
-                chr(ord('T')),
-                chr(ord('H')),
-                chr(ord('E')),
-                chr(ord('O'))
-            )
+            if cv2.__version__.startswith('2'): # OpenCV 2
+                fourcc = cv2.cv.CV_FOURCC(
+                    chr(ord('T')),
+                    chr(ord('H')),
+                    chr(ord('E')),
+                    chr(ord('O'))
+                )
+            elif cv2.__version__.startswith('3'): # OpenCV 3
+                fourcc = cv2.VideoWriter_fourcc(
+                    chr(ord('T')),
+                    chr(ord('H')),
+                    chr(ord('E')),
+                    chr(ord('O'))
+                )
             writer = cv2.VideoWriter(
                 videofile,
                 fourcc,

--- a/py/server.py
+++ b/py/server.py
@@ -203,10 +203,9 @@ def pane(args):
 
     return {
         'command': 'pane',
-        'id': uid,
+        'id': str(uid),
         'title': '' if args.get('title') is None else args['title'],
         'contentID': get_rand_id(),   # to detected updated panes
-
     }
 
 

--- a/py/server.py
+++ b/py/server.py
@@ -60,6 +60,17 @@ def get_path(filename):
     return os.path.join(cwd, filename)
 
 
+def extract_eid(args):
+    """Extract eid from args. If eid does not exist in args,
+    it returns 'main'."""
+
+    eid = 'main' if args.get('eid') is None else args.get('eid')
+    # Replace slashes with underscores, to avoid recognizing them
+    # as directories.
+    eid = eid.replace('/', '_')
+    return eid
+
+
 tornado_settings = {
     "autoescape": None,
     "debug": "/dbg/" in __file__,
@@ -231,7 +242,7 @@ class PostHandler(BaseHandler):
 
         ptype = args['data'][0]['type']
         p = pane(args)
-        eid = 'main' if args.get('eid') is None else args.get('eid')
+        eid = extract_eid(args)
 
         if ptype in ['image', 'text']:
             p.update(dict(content=args['data'][0]['content'], type=ptype))
@@ -283,7 +294,7 @@ class UpdateHandler(BaseHandler):
 
     def post(self):
         args = tornado.escape.json_decode(tornado.escape.to_basestring(self.request.body))
-        eid = 'main' if args.get('eid') is None else args.get('eid')
+        eid = extract_eid(args)
 
         if args['win'] not in self.state[eid]['jsons']:
             self.write('win does not exist')
@@ -310,7 +321,7 @@ class CloseHandler(BaseHandler):
     def post(self):
         args = tornado.escape.json_decode(tornado.escape.to_basestring(self.request.body))
 
-        eid = 'main' if args.get('eid') is None else args.get('eid')
+        eid = extract_eid(args)
         win = args.get('win')
 
         keys = list(self.state[eid]['jsons'].keys()) if win is None else [win]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
 setup(
     # Metadata
     name='visdom',
-    version='0.1.01',
+    version='0.1.04',
     author='Allan Jabri',
     author_email='ajabri@fb.com',
     url='https://github.com/facebookresearch/visdom',

--- a/th/init.lua
+++ b/th/init.lua
@@ -536,11 +536,10 @@ M.line = argcheck{
             options = options, append = update == 'append',
          }
       end
-            -- assertions on the inputs:
-      Y = Y:squeeze()
+
+      -- assertions on the inputs:
       assert(Y:dim() == 1 or Y:dim() == 2, 'Y should be one or two-dimensional')
       if X then
-         X = X:squeeze()
          assert(X:dim() == 1 or X:dim() == 2,
             'X should be one or two-dimensional')
       else

--- a/th/init.lua
+++ b/th/init.lua
@@ -1093,7 +1093,7 @@ M.pie = argcheck{
 -- image:
 M.image = argcheck{
    doc = [[
-      This function draws an img. It takes as input an `CxWxH` tensor `img`
+      This function draws an img. It takes as input an `CxHxW` tensor `img`
       that contains the image.
 
       The following `options` are supported:
@@ -1156,7 +1156,7 @@ end
 -- SVG object:
 M.svg = argcheck{
    doc = [[
-      This function draws an SVG object. It takes as input a SVG string or the
+      This function draws an SVG object. It takes as input an SVG string or the
       name of an SVG file. The function does not support any plot-specific
       `options`.
    ]],

--- a/th/init.lua
+++ b/th/init.lua
@@ -285,6 +285,7 @@ M.sendRequest = argcheck{
       build the required JSON yourself. `endpoint` specifies the destination
       Tornado server endpoint for the request.
    ]],
+   noordered = true,
    {name = 'self',     type = 'visdom.client'},
    {name = 'request',  type = 'table'},
    {name = 'endpoint', type = 'string',  opt = true},
@@ -327,9 +328,12 @@ M.save = argcheck{
          for _,v in pairs(envs) do assert(type(v) == 'string') end
 
          -- send save request to server
-         return self:sendRequest({
-            data   = envs,
-         }, 'save')
+         return self:sendRequest{
+            request = {
+               data = envs,
+            },
+            endpoint = 'save',
+         }
       end
    end
 }
@@ -386,13 +390,13 @@ M.updateTrace = argcheck{
 
       -- send scatter plot request to server:
       return self:sendRequest{
-         request = ({
+         request = {
             data      = nan2null(data),
             win       = win,
             eid       = env,
             name      = name,
             append    = append,
-         }),
+         },
          endpoint = 'update',
       }
    end
@@ -500,12 +504,12 @@ M.scatter = argcheck{
       end
 
       -- send scatter plot request to server:
-      return self:sendRequest({
+      return self:sendRequest{request = {
          data   = nan2null(data),
          win    = win,
          eid    = env,
          layout = options2layout{options = options, is3d = is3d},
-      })
+      }}
    end
 }
 
@@ -708,12 +712,12 @@ M.heatmap = argcheck{
       }}
 
       -- send heatmap plot request to server:
-      return self:sendRequest({
+      return self:sendRequest{request = {
          data   = data,
          win    = win,
          eid    = env,
          layout = options2layout{options = options},
-      })
+      }}
    end
 }
 
@@ -780,12 +784,12 @@ M.bar = argcheck{
       end
 
       -- send bar plot request to server:
-      return self:sendRequest({
+      return self:sendRequest{request = {
          data   = data,
          win    = win,
          eid    = env,
          layout = options2layout{options = options},
-      })
+      }}
    end
 }
 
@@ -877,12 +881,12 @@ M.boxplot = argcheck{
       end
 
       -- send boxplot request to server:
-      return self:sendRequest({
+      return self:sendRequest{request = {
          data   = data,
          win    = win,
          eid    = env,
          layout = options2layout{options = options},
-      })
+      }}
    end
 }
 
@@ -910,7 +914,7 @@ local function _surface(self, X, type, options, win, env)
    }}
 
    -- send 3d surface plot request to server:
-   return self:sendRequest({
+   return self:sendRequest{request = {
       data   = data,
       win    = win,
       eid    = env,
@@ -918,7 +922,7 @@ local function _surface(self, X, type, options, win, env)
          options = options,
          is3d = type == 'surface' and true or nil
       },
-   })
+   }}
 end
 
 -- 3d surface plot:
@@ -1094,12 +1098,12 @@ M.pie = argcheck{
       }}
 
       -- send 3d surface plot request to server:
-      return self:sendRequest({
+      return self:sendRequest{request = {
          data   = data,
          win    = win,
          eid    = env,
          layout = options2layout{options = options},
-      })
+      }}
    end
 }
 
@@ -1148,12 +1152,12 @@ M.mesh = argcheck{
          opacity = options.opacity,
          type = is3d and 'mesh3d' or 'mesh',
       }}
-      return self:sendRequest({
+      return self:sendRequest{request = {
          data   = data,
          win    = win,
          eid    = env,
          layout = options2layout{options = options},
-      })
+      }}
    end
 }
 
@@ -1199,12 +1203,12 @@ M.image = argcheck{
       }}  -- NOTE: This is not a plotly type
 
       -- send image request:
-      return self:sendRequest({
+      return self:sendRequest{request = {
          data   = data,
          win    = win,
          eid    = env,
          title  = options.title,
-      })
+      }}
    end
 }
 
@@ -1340,12 +1344,12 @@ M.text = argcheck{
       }}  -- NOTE: This is not a plotly type
 
       -- send text request:
-      return self:sendRequest({
+      return self:sendRequest{request = {
          data   = data,
          win    = win,
          eid    = env,
          title  = options.title,
-      })
+      }}
    end
 }
 

--- a/th/init.lua
+++ b/th/init.lua
@@ -1141,6 +1141,50 @@ M.image = argcheck{
    end
 }
 
+-- helper function for loading file as bytestring:
+local function loadFile(filename)
+   local paths = require 'paths'
+   assert(paths.filep(filename),
+      string.format('file not found: %s', filename))
+   local file = io.open(filename, 'r')
+   assert(file, string.format('could not open file: %s', filename))
+   local str = file:read('*all')
+   file:close()
+   return str
+end
+
+-- SVG object:
+M.svg = argcheck{
+   doc = [[
+      This function draws an SVG object. It takes as input a SVG string or the
+      name of an SVG file. The function does not support any plot-specific
+      `options`.
+   ]],
+   noordered = true,
+   {name = 'self',    type = 'visdom.client'},
+   {name = 'svgstr',  type = 'string', opt = true},
+   {name = 'svgfile', type = 'string', opt = true},
+   {name = 'options', type = 'table',  opt = true},
+   {name = 'win',     type = 'string', opt = true},
+   {name = 'env',     type = 'string', opt = true},
+   call = function(self, svgstr, svgfile, options, win, env)
+
+      -- load SVG and strip doctype if it is present:
+      assert(svgstr or svgfile, 'should specify SVG string or filename')
+      local svgstr = svgstr or loadFile(svgfile)
+      local svg = svgstr:match('<svg .+</svg>')
+      assert(svg, 'SVG could not be parsed correctly')
+
+      -- send SVG request:
+      return (self:text{
+         text    = svg,
+         options = options,
+         win     = win,
+         eid     = env,
+      })
+   end
+}
+
 -- text:
 M.text = argcheck{
    doc = [[

--- a/th/init.lua
+++ b/th/init.lua
@@ -1119,10 +1119,10 @@ M.image = argcheck{
       options.jpgquality = options.jpgquality or 100
       assertOptions{options = options}
 
-      -- convert to JPG bytestring to base64:
       local immem = image.compressJPG(img, options.jpgquality)
       local imgdata = 'data:image/jpg;base64,' ..
          mime.b64(ffi.string(immem:data(), immem:nElement()))
+
       local imsize = (img:dim() == 2 and img or img[1]):size():totable()
 
       -- make data object:
@@ -1182,69 +1182,6 @@ M.svg = argcheck{
       -- send SVG request:
       return (self:text{
          text    = svg,
-         options = options,
-         win     = win,
-         eid     = env,
-      })
-   end
-}
-
--- video file:
-M.video = argcheck{
-   doc = [[
-      This function plays a video. It takes as input the filename of the video
-      or a `LxCxHxW` tensor containing all the frames of the video. The function
-      does not support any plot-specific `options`.
-   ]],
-   noordered = true,
-   {name = 'self',      type = 'visdom.client'},
-   {name = 'tensor',    type = 'torch.ByteTensor', opt = true},
-   {name = 'videofile', type = 'string', opt = true},
-   {name = 'options',   type = 'table',  opt = true},
-   {name = 'win',       type = 'string', opt = true},
-   {name = 'env',       type = 'string', opt = true},
-   call = function(self, tensor, videofile, options, win, env)
-
-      -- get mime type for video:
-      videofile = videofile or os.tmpname() .. '.ogv'
-      assert(tensor or videofile, 'should specify video tensor or file')
-      local extension = videofile:sub(-3):lower()
-      local mimetypes = {
-         mp4  = 'mp4',
-         ogv  = 'ogg',
-         avi  = 'avi',
-         webm = 'webm',
-      }
-      local mimetype = mimetypes[extension]
-      assert(mimetype, string.format('unknown video type: %s', extension))
-
-      -- construct video if a tensor was specified:
-      if tensor then
-         assert(tensor:nDimension() == 4, 'video should be in 4D tensor')
-         local ffmpeg = require 'ffmpeg'
-         local video = ffmpeg.Video{
-            height = tensor:size(3),
-            width  = tensor:size(4),
-            fps    = 25,
-            length = tensor:size(1),
-            tensor = tensor,
-            zoom   = 2,
-         }
-         video:save{outpath = videofile, keep = false, usetheora = true}
-      end
-
-      -- load video file:
-      local bytestr = loadFile(videofile)
-
-      -- send out video request:
-      local videodata = string.format([[
-         <video controls>
-            <source type="video/%s" src="data:video/%s;base64,%s">
-            Your browser does not support the video tag.
-         </video>
-      ]], mimetype, mimetype, mime.b64(bytestr))
-      return (self:text{
-         text    = videodata,
          options = options,
          win     = win,
          eid     = env,

--- a/th/init.lua
+++ b/th/init.lua
@@ -1212,6 +1212,36 @@ M.image = argcheck{
    end
 }
 
+--images:
+M.images = argcheck{
+   doc = [[
+      This function makes a grid of images. It takes either a table of image
+      Tensors H x W (greyscale) or nChannel x H x W (color), or a single Tensor
+      of size batchSize x nChannel x H x W or nChannel x H x W where
+      nChannel=[3,1], batchSize x H x W or H x W.
+   ]],
+   noordered = true,
+   force = true,
+   {name = 'self',    type = 'visdom.client'},
+   {name = 'table',   type = 'table',  opt = true},
+   {name = 'tensor',  type = 'torch.*Tensor', opt = true},
+   {name = 'nrow',    type = 'number', opt = true},
+   {name = 'padding', type = 'number', opt = true},
+   {name = 'options', type = 'table',  opt = true},
+   {name = 'win',     type = 'string', opt = true},
+   {name = 'env',     type = 'string', opt = true},
+   call = function(self, table, tensor, nrow, padding, options, win, env)
+      assert(table or tensor)
+      return self:image{
+        img = image.toDisplayTensor{
+          input = table or tensor, padding = padding, nrow = nrow},
+        options = options,
+        win = win,
+        env = env
+      }
+   end
+}
+
 -- helper function for loading file as bytestring:
 local function loadFile(filename)
    local paths = require 'paths'

--- a/th/visdom-scm-1.rockspec
+++ b/th/visdom-scm-1.rockspec
@@ -24,6 +24,7 @@ dependencies = {
    "luasocket >= 1.0",
    "json >= 1.0",
    "luaffi >= 1.0",
+   "paths >= 1.0",
 }
 
 build = {

--- a/th/visdom-scm-1.rockspec
+++ b/th/visdom-scm-1.rockspec
@@ -24,7 +24,6 @@ dependencies = {
    "luasocket >= 1.0",
    "json >= 1.0",
    "luaffi >= 1.0",
-   "paths >= 1.0",
 }
 
 build = {


### PR DESCRIPTION
This addresses #72, changing `opts` to `options` throughout. Solves potential confusion for new users by making the Python interface consistent with the Lua interface and documentation.

To avoid breaking old code, the methods that take `options` are also wrapped to accept `opts` in the kwargs.