### PR TITLE
Disable requests root loggers for most messages

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -22,6 +22,11 @@ import base64 as b64
 import numbers
 from six import string_types
 from six import BytesIO
+import logging
+
+
+logging.getLogger('requests').setLevel(logging.CRITICAL)
+logging.getLogger('urllib3').setLevel(logging.CRITICAL)
 
 
 def isstr(s):


### PR DESCRIPTION
If your code uses a root logger, you shouldn't have to deal with Visdom throwing `INFO` logs from urrlib3. This patch sets `requests` and `urrlib3` loggers to `CRITICAL` by default (which the user can then change back if debugging or interested in the state of the requests.