### PR TITLE
Add PyTorch tensor support to `images`

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -193,8 +193,8 @@ def pytorch_wrap(fn):
 
 def wrap_tensor_methods(cls, wrapper):
     fns = ['_surface', 'bar', 'boxplot', 'surf', 'heatmap', 'histogram', 'svg',
-            'image', 'line', 'pie', 'scatter', 'stem', 'quiver', 'contour',
-            'updateTrace']
+           'image', 'images', 'line', 'pie', 'scatter', 'stem', 'quiver', 'contour',
+           'updateTrace']
     for key in [k for k in dir(cls) if k in fns]:
         setattr(cls, key, wrapper(getattr(cls, key)))
 


### PR DESCRIPTION
`images` was not supporting PyTorch tensors, while [Torch version looks supporting it](https://github.com/facebookresearch/visdom/blob/master/th/init.lua#L1242).
Added it in `wrap_tensor_methods`.
And also fixed indentations.