### PR TITLE
Fixed Markercolor Not Working in Torch7

### DIFF
--- a/th/init.lua
+++ b/th/init.lua
@@ -178,7 +178,7 @@ local markerColorCheck = argcheck{
       else  -- mc = N x 3
           markercolor = {}
           for i = 1, mc:size(1) do
-              markercolor[i] = string.format('#%x%x%x', mc[i][1],
+              markercolor[i] = string.format('#%02x%02x%02x', mc[i][1],
                                                      mc[i][2], mc[i][3])
           end
       end


### PR DESCRIPTION
Fixed a bug with the _markercolor_ property of any plot that prevented the
plot from properly displaying the colors that were supplied via Torch7.  This is
due to a difference between Python and Lua string formatting.

A simple test can be run to show this erroneous behavior:

```lua
print(string.format("#%x%x%x",5,3,0))
```

produces:
```
#530
```
which is not the correct color specified, whereas:

```lua
print(string.format("#%02x%02x%02x",5,3,0))
```

produces the correctly formatted color:
```
#050300
```
