### PR TITLE
Window Missing Name Fix

### DIFF
--- a/example/demo.py
+++ b/example/demo.py
@@ -24,6 +24,7 @@ assert viz.check_connection()
 textwindow = viz.text('Hello World!')
 
 updatetextwindow = viz.text('Hello World! More text should be here')
+assert updatetextwindow is not None, 'Window was none'
 viz.text('And here it is', win=updatetextwindow, append=True)
 
 # video demo:

--- a/py/server.py
+++ b/py/server.py
@@ -218,6 +218,8 @@ class BaseHandler(tornado.web.RequestHandler):
 def window(args):
     """ Build a window dict structure for sending to client """
     uid = args.get('win', 'window_' + get_rand_id())
+    if uid is None:
+        uid = 'window_' + get_rand_id()
     opts = args.get('opts', {})
 
     ptype = args['data'][0]['type']

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 setup(
     # Metadata
     name='visdom',
-    version='0.1.06',
+    version='0.1.6.1',
     author='Allan Jabri',
     author_email='ajabri@fb.com',
     url='https://github.com/facebookresearch/visdom',


### PR DESCRIPTION
A recent change made it so that the server would return "None" (the string) as the name of any window that was not explicitly given a name, rather than generating a unique name like it was supposed to. This occurred because the arguments were recently forced to instantiate the window name to None (based on default args) and we didn't have a check to notice that it happened. 

This PR fixes the problem and adds a check to our python demo