### PR TITLE
Fixed videofile extension extraction (for webm)

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -500,7 +500,7 @@ class Visdom(object):
             writer.release()
             writer = None
 
-        extension = videofile[-3:].lower()
+        extension = videofile.split(".")[-1].lower()
         mimetypes = dict(mp4='mp4', ogv='ogg', avi='avi', webm='webm')
         mimetype = mimetypes.get(extension)
         assert mimetype is not None, 'unknown video type: %s' % extension


### PR DESCRIPTION
Currently, due to the string "webm" having 4 characters, the extension extracted from `videofile` would be "ebm", which doesn't match any of the allowed extensions.