### PR TITLE
py: use binary flag in from_t7

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -57,11 +57,11 @@ def from_t7(t, b64=False):
     if b64:
         t = base64.b64decode(t)
 
-    with open('/dev/shm/t7', 'w') as ff:
+    with open('/dev/shm/t7', 'wb') as ff:
         ff.write(t)
         ff.close()
 
-    sf = open('/dev/shm/t7')
+    sf = open('/dev/shm/t7', 'rb')
 
     return torchfile.T7Reader(sf).read_obj()
 


### PR DESCRIPTION
This fixes a regression introduced in 1753e20f4ba805cb94d3646d472c53bc8d990a2a. At least on Python 3.5, files need to be opened with the binary flag to be able to read/write `bytes` objects from/to them.

I guess this commit was only tested on Python 2.7, where there is no distinction between text and binary files.

A typical backtrace looks like this:
```
Traceback (most recent call last):
  File "/home/schwarzm/.local/lib/python3.5/site-packages/visdom-0.1.6.3-py3.5.egg/visdom/server.py", line 312, in post
    req, endpoint = self.func(req)
  File "/home/schwarzm/.local/lib/python3.5/site-packages/visdom-0.1.6.3-py3.5.egg/visdom/server.py", line 299, in func
    kwargs[k] = unpack_lua(v)
  File "/home/schwarzm/.local/lib/python3.5/site-packages/visdom-0.1.6.3-py3.5.egg/visdom/server.py", line 275, in unpack_lua
    return visdom.from_t7(req_args['val'], b64=True)
  File "/home/schwarzm/.local/lib/python3.5/site-packages/visdom-0.1.6.3-py3.5.egg/visdom/__init__.py", line 66, in from_t7
    ff.write(t)
TypeError: write() argument must be str, not bytes
```