### PR TITLE
Uni-dimensional values with legend in bar plots

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -815,7 +815,13 @@ class Visdom(object):
         X = np.squeeze(X)
         assert X.ndim == 1 or X.ndim == 2, 'X should be one or two-dimensional'
         if X.ndim == 1:
-            X = X[:, None]
+            if opts.get('legend') is not None:
+                X = X[None, :]
+                assert opts.get('rownames') is None, \
+                    'both rownames and legend cannot be specified \
+                    for one-dimensional X values'
+            else:
+                X = X[:, None]
         if Y is not None:
             Y = np.squeeze(Y)
             assert Y.ndim == 1, 'Y should be one-dimensional'
@@ -834,7 +840,7 @@ class Visdom(object):
 
         if opts.get('legend') is not None:
             assert len(opts['legend']) == X.shape[1], \
-                'number of legened labels must match number of columns in X'
+                'number of legend labels must match number of columns in X'
 
         data = []
         for k in range(X.shape[1]):


### PR DESCRIPTION
Consider the following example with a uni-dimensional X value that can be interpreted as either `N x 1` or `1 x N` vector. The visdom `bar` function only allows specifying `rownames` for this and not `legend`.

```python
from visdom import Visdom
import numpy as np

bar_hts = np.array([1, 2, 3])
bar_labels = ['a', 'b', 'c']
viz_obj = Visdom(server='http://localhost', port=8097)
viz_obj.bar(X=bar_hts, opts=dict(rownames=bar_labels))
viz_obj.bar(X=bar_hts, opts=dict(legend=bar_labels))
```
The last line does not execute and throws the following error - 
```
Traceback (most recent call last):
  File "reproduce_visdom_bug.py", line 8, in <module>
    viz_obj.bar(X=bar_hts, opts=dict(legend=bar_labels))
  File "/home/imisra/anaconda/lib/python3.6/site-packages/visdom/__init__.py", line 208, in result
    return fn(*args, **kwargs)
  File "/home/imisra/anacondalib/python3.6/site-packages/visdom/__init__.py", line 837, in bar
    'number of legened labels must match number of columns in X'
AssertionError: number of legened labels must match number of columns in X
```
With the proposed changes the `bar` function now can accept either `rownames` or `legend` and display them correctly for uni-dimensional X values.