### PR TITLE
Update __init__.py

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -460,7 +460,7 @@ class Visdom(object):
     def video(self, tensor=None, videofile=None, win=None, env=None, opts=None):
         """
         This function plays a video. It takes as input the filename of the video
-        or a `LxCxHxW` tensor containing all the frames of the video. The function
+        or a `LxHxWxC` tensor containing all the frames of the video. The function
         does not support any plot-specific `options`.
         """
         opts = {} if opts is None else opts


### PR DESCRIPTION
amini2nt-video-documentation
Following the conversation [here](https://github.com/facebookresearch/visdom/issues/209):
In the video method, it is mentioned that each tensor should be of shape `LxCxHxW`, however, the correct version of this is actually `LxHxWxC`.