### PR TITLE
Splitting error handling for accuracy

### DIFF
--- a/py/server.py
+++ b/py/server.py
@@ -732,8 +732,12 @@ def download_scripts(proxies=None, install_dir=None):
                 data = opener.open(req).read()
                 with open(filename, 'wb') as fwrite:
                     fwrite.write(data)
-            except (HTTPError, URLError) as exc:
-                logging.error('Error {} while downloading {}'.format(exc.code, key))
+            except HTTPError as exc:
+                logging.error('Error {} while downloading {}'.format(
+                    exc.code, key))
+            except URLError as exc:
+                logging.error('Error {} while downloading {}'.format(
+                    exc.reason, key))
 
 
 def main(print_func=None):


### PR DESCRIPTION
Right now the error reporting for URLErrors when downloading sources is broken. This means people will open issues and not be able to tell what went wrong. (https://github.com/facebookresearch/visdom/issues/240 for example) 

This commit fixes that and allows both error types to report 