### PR TITLE
Use PNG instead of JPG for temp image saving

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -403,7 +403,7 @@ class Visdom(object):
 
         data = [{
             'content': {
-                'src': 'data:image/jpg;base64,' + b64encoded,
+                'src': 'data:image/png;base64,' + b64encoded,
                 'caption': opts.get('caption'),
             },
             'type': 'image',

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -381,7 +381,6 @@ class Visdom(object):
         uint8 in [0, 255].
         """
         opts = {} if opts is None else opts
-        opts['jpgquality'] = opts.get('jpgquality', 75)
         _assert_opts(opts)
         opts['width'] = opts.get('width', img.shape[img.ndim - 1])
         opts['height'] = opts.get('height', img.shape[img.ndim - 2])
@@ -399,7 +398,7 @@ class Visdom(object):
         img = np.transpose(img, (1, 2, 0))
         im = Image.fromarray(img)
         buf = BytesIO()
-        im.save(buf, format='JPEG', quality=opts['jpgquality'])
+        im.save(buf, format='PNG')
         b64encoded = b64.b64encode(buf.getvalue()).decode('utf-8')
 
         data = [{


### PR DESCRIPTION
Use PNG for temp image saving format to mitigate artifacts from JPEG. Since most people using this tool care more about image accuracy than compression, IMO this should be the default.

 ![test](https://user-images.githubusercontent.com/1448621/34694549-764a98d8-f495-11e7-9558-cfe32b192d84.jpg) JPEG (quality: 100)
![test](https://user-images.githubusercontent.com/1448621/34694551-776171c4-f495-11e7-8d28-f158bcba747e.png) PNG 
