### PR TITLE
Better plotly feature parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,8 @@ The following `opts` are supported:
 - `opts.markercolor` : color per marker. (`torch.*Tensor`; default = `nil`)
 - `opts.legend`      : `table` containing legend names
 - `opts.textlabels`  : text label for each point (`list`: default = `None`)
-- `opts.layoutopts`  : dict of any additional options that plotly accepts for a layout
-- `opts.traceopts`   : dict mapping trace names or indices to dicts of additional options that plotly accepts for a trace.
+- `opts.layoutopts`  : dict of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
+- `opts.traceopts`   : dict mapping trace names or indices to dicts of additional options that the graph backend accepts. For example `traceopts = {'plotly': {'myTrace': {'mode': 'markers'}}}`.
 
 `opts.markercolor` is a Tensor with Integer values. The tensor can be of size `N` or `N x 3` or `K` or `K x 3`.
 
@@ -376,7 +376,7 @@ The following `opts` are supported:
 - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
 - `opts.markersize`  : marker size (`number`; default = `'10'`)
 - `opts.legend`      : `table` containing legend names
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`   : `dict` mapping trace names or indices to `dict`s of additional options that plot.ly accepts for a trace.
 
 
@@ -411,7 +411,7 @@ The following `opts` are supported:
 
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.legend`  : `table` containing legend names
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.heatmap
 This function draws a heatmap. It takes as input an `NxM` tensor `X` that
@@ -424,7 +424,7 @@ The following `opts` are supported:
 - `opts.xmax`       : clip maximum value (`number`; default = `X:max()`)
 - `opts.columnnames`: `table` containing x-axis labels
 - `opts.rownames`   : `table` containing y-axis labels
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.bar
 This function draws a regular, stacked, or grouped bar plot. It takes as
@@ -439,7 +439,7 @@ The following plot-specific `opts` are currently supported:
 - `opts.rownames`: `table` containing x-axis labels
 - `opts.stacked`    : stack multiple columns in `X`
 - `opts.legend`     : `table` containing legend labels
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.histogram
 This function draws a histogram of the specified data. It takes as input
@@ -449,7 +449,7 @@ histogram.
 The following plot-specific `opts` are currently supported:
 
 - `opts.numbins`: number of bins (`number`; default = 30)
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.boxplot
 This function draws boxplots of the specified data. It takes as input
@@ -459,7 +459,7 @@ to construct the `M` boxplots.
 The following plot-specific `opts` are currently supported:
 
 - `opts.legend`: labels for each of the columns in `X`
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.surf
 This function draws a surface plot. It takes as input an `NxM` tensor `X`
@@ -470,7 +470,7 @@ The following `opts` are supported:
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.contour
 This function draws a contour plot. It takes as input an `NxM` tensor `X`
@@ -481,7 +481,7 @@ The following `opts` are supported:
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.quiver
 This function draws a quiver plot in which the direction and length of the
@@ -493,7 +493,7 @@ The following `opts` are supported:
 
 - `opts.normalize`:  length of longest arrows (`number`)
 - `opts.arrowheads`: show arrow heads (`boolean`; default = `true`)
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.mesh
 This function draws a mesh plot from a set of vertices defined in an
@@ -504,7 +504,7 @@ The following `opts` are supported:
 
 - `opts.color`: color (`string`)
 - `opts.opacity`: opacity of polygons (`number` between 0 and 1)
-- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 ### Customizing plots
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ The following `opts` are supported:
 - `opts.markercolor` : color per marker. (`torch.*Tensor`; default = `nil`)
 - `opts.legend`      : `table` containing legend names
 - `opts.textlabels`  : text label for each point (`list`: default = `None`)
+- `opts.layoutopts`  : dict of any additional options that plotly accepts for a layout
+- `opts.traceopts`   : dict mapping trace names or indices to dicts of additional options that plotly accepts for a trace.
 
 `opts.markercolor` is a Tensor with Integer values. The tensor can be of size `N` or `N x 3` or `K` or `K x 3`.
 
@@ -374,6 +376,8 @@ The following `opts` are supported:
 - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
 - `opts.markersize`  : marker size (`number`; default = `'10'`)
 - `opts.legend`      : `table` containing legend names
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
+- `opts.traceopts`   : `dict` mapping trace names or indices to `dict`s of additional options that plot.ly accepts for a trace.
 
 
 #### vis.updateTrace
@@ -407,6 +411,7 @@ The following `opts` are supported:
 
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.legend`  : `table` containing legend names
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 #### vis.heatmap
 This function draws a heatmap. It takes as input an `NxM` tensor `X` that
@@ -419,6 +424,7 @@ The following `opts` are supported:
 - `opts.xmax`       : clip maximum value (`number`; default = `X:max()`)
 - `opts.columnnames`: `table` containing x-axis labels
 - `opts.rownames`   : `table` containing y-axis labels
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 #### vis.bar
 This function draws a regular, stacked, or grouped bar plot. It takes as
@@ -433,6 +439,7 @@ The following plot-specific `opts` are currently supported:
 - `opts.rownames`: `table` containing x-axis labels
 - `opts.stacked`    : stack multiple columns in `X`
 - `opts.legend`     : `table` containing legend labels
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 #### vis.histogram
 This function draws a histogram of the specified data. It takes as input
@@ -442,6 +449,7 @@ histogram.
 The following plot-specific `opts` are currently supported:
 
 - `opts.numbins`: number of bins (`number`; default = 30)
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 #### vis.boxplot
 This function draws boxplots of the specified data. It takes as input
@@ -451,6 +459,7 @@ to construct the `M` boxplots.
 The following plot-specific `opts` are currently supported:
 
 - `opts.legend`: labels for each of the columns in `X`
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 #### vis.surf
 This function draws a surface plot. It takes as input an `NxM` tensor `X`
@@ -461,6 +470,7 @@ The following `opts` are supported:
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 #### vis.contour
 This function draws a contour plot. It takes as input an `NxM` tensor `X`
@@ -471,6 +481,7 @@ The following `opts` are supported:
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 #### vis.quiver
 This function draws a quiver plot in which the direction and length of the
@@ -482,6 +493,7 @@ The following `opts` are supported:
 
 - `opts.normalize`:  length of longest arrows (`number`)
 - `opts.arrowheads`: show arrow heads (`boolean`; default = `true`)
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 #### vis.mesh
 This function draws a mesh plot from a set of vertices defined in an
@@ -492,12 +504,13 @@ The following `opts` are supported:
 
 - `opts.color`: color (`string`)
 - `opts.opacity`: opacity of polygons (`number` between 0 and 1)
+- `opts.layoutopts`  : `dict` of any additional options that plot.ly accepts for a layout
 
 ### Customizing plots
 
 The plotting functions take an optional `opts` table as input that can be used to change (generic or plot-specific) properties of the plots. All input arguments are specified in a single table; the input arguments are matches based on the keys they have in the input table.
 
-The following `opts` are generic in the sense that they are the same for all visualizations (except `plot.image` and `plot.text`):
+The following `opts` are generic in the sense that they are the same for all visualizations (except `plot.image`, `plot.text`, `plot.video`, and `plot.audio`):
 
 - `opts.title`       : figure title
 - `opts.width`       : figure width

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -123,6 +123,9 @@ def _opts2layout(opts, is3d=False):
     if opts.get('stacked'):
         layout['barmode'] = 'stack' if opts.get('stacked') else 'group'
 
+    if opts.get('layoutopts') is not None:
+        layout.update(opts.get('layoutopts'))
+
     return _scrub_dict(layout)
 
 
@@ -799,6 +802,7 @@ class Visdom(object):
             assert type(opts['legend']) == list and len(opts['legend']) == K
 
         data = []
+        trace_opts = opts.get('traceopts', {})
         for k in range(1, K + 1):
             ind = np.equal(Y, k)
             if ind.any():
@@ -832,6 +836,9 @@ class Visdom(object):
 
                 if is3d:
                     _data['z'] = X.take(2, 1)[ind].tolist()
+
+                if trace_name in trace_opts:
+                    _data.update(trace_opts[trace_name])
 
                 data.append(_scrub_dict(_data))
 

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -123,8 +123,10 @@ def _opts2layout(opts, is3d=False):
     if opts.get('stacked'):
         layout['barmode'] = 'stack' if opts.get('stacked') else 'group'
 
-    if opts.get('layoutopts') is not None:
-        layout.update(opts.get('layoutopts'))
+    layout_opts = opts.get('layoutopts')
+    if layout_opts is not None:
+        if 'plotly' in layout_opts:
+            layout.update(layout_opts['plotly'])
 
     return _scrub_dict(layout)
 
@@ -802,7 +804,7 @@ class Visdom(object):
             assert type(opts['legend']) == list and len(opts['legend']) == K
 
         data = []
-        trace_opts = opts.get('traceopts', {})
+        trace_opts = opts.get('traceopts', {'plotly': {}})['plotly']
         for k in range(1, K + 1):
             ind = np.equal(Y, k)
             if ind.any():


### PR DESCRIPTION
Better supports general plotly features by adding opts to specify additional layout opts that we don't manage and additional trace options that we don't already provide.

On the downside it means there are now 2 ways to accomplish most of the things that we directly support, but those that use the plotly way are already versed enough in the plotly formatting to not necessarily need to use our implementation anyways, and our implementation is still better for people unfamiliar with plotly.

Closes #201, as error bars are implemented using trace options in plotly, so they are now possible for us as well.
Closes #197, as this is a layout option that we can now pass along.
Closes #200 for the same reason as above.

Prevents future "plotly does it but visdom doesn't" feature requests.