### PR TITLE
Adding websocket to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ requirements = [
     'pyzmq',
     'six',
     'torchfile',
+    'websocket-client',
 ]
 
 setup(


### PR DESCRIPTION
Forgot to add this to the requirements when websocket support was launched. Now added after being brought up in #274