### PR TITLE
allow to plot one point once

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -801,6 +801,7 @@ class Visdom(object):
                     Y = None
 
         assert X.ndim == 2, 'X should have two dims'
+
         assert X.shape[1] == 2 or X.shape[1] == 3, 'X should have 2 or 3 cols'
 
         if Y is not None:
@@ -925,6 +926,11 @@ class Visdom(object):
             else:
                 assert X is not None, 'must specify x-values for line update'
         assert Y.ndim == 1 or Y.ndim == 2, 'Y should have 1 or 2 dim'
+        if Y.ndim == 2:
+            assert Y.shape[1] > 0, 'must plot one line at least'
+            if Y.shape[1] == 1:
+                Y = Y.reshape(Y.shape[0])
+                X = X.reshape(X.shape[0])
 
         if X is not None:
             assert X.ndim == 1 or X.ndim == 2, 'X should have 1 or 2 dim'


### PR DESCRIPTION
When useing visdom **line function** to plot  Real-time  train loss ， It is necessary to append one new point to orgin loss curve。 but in origin code if we  call line  as below 
 `line(np.array([[train_step]], np.array([[train_loss]])) , win='loss', name='model_one', update='append' )`
it will report error from here.
`
Y = np.squeeze(Y)
assert Y.ndim == 1, 'Y should be one-dimensional'
`
So I  read the fuction code  and modify it to support ploting real-time loss curve. and I'm not sure if this will have any side effect