### PR TITLE
fix some bugs about plot multiple point in one line 

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -801,6 +801,7 @@ class Visdom(object):
                     Y = None
 
         assert X.ndim == 2, 'X should have two dims'
+
         assert X.shape[1] == 2 or X.shape[1] == 3, 'X should have 2 or 3 cols'
 
         if Y is not None:
@@ -925,6 +926,11 @@ class Visdom(object):
             else:
                 assert X is not None, 'must specify x-values for line update'
         assert Y.ndim == 1 or Y.ndim == 2, 'Y should have 1 or 2 dim'
+        if Y.ndim == 2:
+            assert Y.shape[1] > 0, 'must plot one line at least'
+            if Y.shape[1] == 1:
+                Y = Y.reshape(Y.shape[0])
+                X = X.reshape(X.shape[0])
 
         if X is not None:
             assert X.ndim == 1 or X.ndim == 2, 'X should have 1 or 2 dim'

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -926,14 +926,15 @@ class Visdom(object):
                 assert X is not None, 'must specify x-values for line update'
         assert Y.ndim == 1 or Y.ndim == 2, 'Y should have 1 or 2 dim'
         assert Y.shape[-1] > 0, 'must plot one line at least'
-        if Y.ndim == 2 and Y.shape[1] == 1:
-                Y = Y.reshape(Y.shape[0])
-                X = X.reshape(X.shape[0])
 
         if X is not None:
             assert X.ndim == 1 or X.ndim == 2, 'X should have 1 or 2 dim'
         else:
             X = np.linspace(0, 1, Y.shape[0])
+
+        if Y.ndim == 2 and Y.shape[1] == 1:
+                Y = Y.reshape(Y.shape[0])
+                X = X.reshape(X.shape[0])
 
         if Y.ndim == 2 and X.ndim == 1:
             X = np.tile(X, (Y.shape[1], 1)).transpose()

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -841,7 +841,7 @@ class Visdom(object):
                 mc = opts.get('markercolor')
                 if 'legend' in opts:
                     trace_name = opts.get('legend')[k - 1]
-                elif X.shape[0] == 1 and name is not None:
+                elif K == 1 and name is not None:
                     trace_name = name
                 else:
                     trace_name = str(k)
@@ -925,9 +925,8 @@ class Visdom(object):
             else:
                 assert X is not None, 'must specify x-values for line update'
         assert Y.ndim == 1 or Y.ndim == 2, 'Y should have 1 or 2 dim'
-        if Y.ndim == 2:
-            assert Y.shape[1] > 0, 'must plot one line at least'
-            if Y.shape[1] == 1:
+        assert Y.shape[-1] > 0, 'must plot one line at least'
+        if Y.ndim == 2 and Y.shape[1] == 1:
                 Y = Y.reshape(Y.shape[0])
                 X = X.reshape(X.shape[0])
 


### PR DESCRIPTION
According the documents

> . It takes as input an N or NxM tensor Y that specifies the values of the M lines (that connect N points) to plot 


I find that if I call line funciton as bellow 
   viz.line(X=np.array([1,2]), Y=np.array([1,2]), win='xx', name='linename') to plot (1,1)  (2,2) on one single  line 
it will  rename it as "1"  rather than "Linename"  

And when you want to add single point on single line as below
 viz.line(X=np.array([[1]]), Y=np.array([[1]]), win='xx', name='linename') 
It will  report error

So , I change the code as below 
1. when intput with Y.shape=(dim1, 1), We  reshape Y  as Y.shape=(dim1) 
2. The origin  code that decide  whether use the number to  name the line is done as below 
elif X.shape[0] == 1 and name is not None:
This will make a mistake when you try to plot multiple points in one line with name.

