### PR TITLE
Return valid json data for get_window_data

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -913,11 +913,6 @@ class DataHandler(BaseHandler):
         else:
             handler.write(json.dumps(handler.state[eid]['jsons']))
 
-        if args['win'] in handler.state[eid]['jsons']:
-            handler.write('true')
-        else:
-            handler.write('false')
-
     def post(self):
         args = tornado.escape.json_decode(
             tornado.escape.to_basestring(self.request.body)


### PR DESCRIPTION
Fix for #329
json.loads() now works correctly and getting a non-existent window will return an empty string

![image](https://user-images.githubusercontent.com/20519655/39605692-4ffbbff6-4ef7-11e8-8b7e-0ed93346d70c.png)