### PR TITLE
Deprecating updateTrace as planned >6 months ago

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can partition your visualization space with `envs`. By default, every user w
 
 You can access a specific env via url: `http://localhost.com:8097/env/main`. If your server is hosted, you can share this url so others can see your visualizations too.
 
-Environments are automatically hierarchically organized by the first `_`. 
+Environments are automatically hierarchically organized by the first `_`.
 
 #### Selecting Environments
 <p align="center"><img align="center" src="https://user-images.githubusercontent.com/1276867/34618242-261d55d4-f20c-11e7-820d-c16731248b26.png" width="300" /></p>
@@ -239,7 +239,6 @@ We have wrapped several common plot types to make creating basic visualizations 
 The following API is currently supported:
 - [`vis.scatter`](#visscatter)  : 2D or 3D scatter plots
 - [`vis.line`](#visline)     : line plots
-- [`vis.updateTrace`](#visupdatetrace)     : update existing line/scatter plots
 - [`vis.stem`](#visstem)     : stem plots
 - [`vis.heatmap`](#visheatmap)  : heatmap plots
 - [`vis.bar`](#visbar)  : bar graphs
@@ -394,26 +393,6 @@ The following `opts` are supported:
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`   : `dict` mapping trace names or indices to `dict`s of additional options that plot.ly accepts for a trace.
 
-
-#### vis.updateTrace
-This function allows updating of data for extant line or scatter plots.
-
-It is up to the user to specify `name` of an existing trace if they want
-to add to it, and a new `name` if they want to add a trace to the plot.
-By default, if no legend is specified at time of first creation,
-the `name` is the index of the line in the legend.
-
-If no `name` is specified, all traces should be updated.
-Trace update data that is all `NaN` is ignored;
-this can be used for masking update.
-
-The `append` parameter determines if the update data should be appended
-to or replaces existing data.
-
-There are no `opts` because they are assumed to be inherited from the
-specified plot.
-
-*Note: This function will be deprecated in upcoming versions.*
 
 #### vis.stem
 This function draws a stem plot. It takes as input an `N` or `NxM` tensor

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -233,8 +233,7 @@ def pytorch_wrap(fn):
 
 def wrap_tensor_methods(cls, wrapper):
     fns = ['_surface', 'bar', 'boxplot', 'surf', 'heatmap', 'histogram', 'svg',
-           'image', 'images', 'line', 'pie', 'scatter', 'stem', 'quiver', 'contour',
-           'updateTrace']
+           'image', 'images', 'line', 'pie', 'scatter', 'stem', 'quiver', 'contour']
     for key in [k for k in dir(cls) if k in fns]:
         setattr(cls, key, wrapper(getattr(cls, key)))
 
@@ -719,61 +718,6 @@ class Visdom(object):
             </video>
         """ % (mimetype, mimetype, base64.b64encode(bytestr).decode('utf-8'))
         return self.text(text=videodata, win=win, env=env, opts=opts)
-
-    def updateTrace(self, X, Y, win, env=None, name=None,
-                    append=True, opts=None):
-        """
-        This function allows updating of the data of a line or scatter plot.
-
-        It is up to the user to specify `name` of an existing trace if they want
-        to add to it, and a new `name` if they want to add a trace to the plot.
-        By default, if no legend is specified, the `name` is the index of the
-        line in the legend.
-
-        If no `name` is specified, all traces should be updated.
-        Update data that is all NaN is ignored (can be used for masking update).
-
-        The `append` parameter determines if the update data should be appended
-        to or replaces existing data.
-
-        There are less options because they are assumed to inherited from the
-        specified plot.
-        """
-        warnings.warn("updateTrace is going to be deprecated in the next "
-                      "version of `visdom`. Please to use `scatter(.., "
-                      "update='append',name=<traceName>)` or `line(.., "
-                      "update='append',name=<traceName>)` as required.",
-                      PendingDeprecationWarning)
-        assert win is not None
-
-        assert Y.shape == X.shape, 'Y should be same size as X'
-        if X.ndim > 2:
-            X = np.squeeze(X)
-            Y = np.squeeze(Y)
-        assert X.ndim == 1 or X.ndim == 2, 'Updated X should be 1 or 2 dim'
-
-        if name:
-            assert len(name) >= 0, 'name of trace should be nonempty string'
-            assert X.ndim == 1, 'updating by name expects 1-dim data'
-
-        if opts is not None and opts.get('markercolor') is not None:
-            K = int(Y.max())
-            opts['markercolor'] = _markerColorCheck(
-                opts['markercolor'], X, Y, K)
-
-        data = {'x': X.transpose().tolist(), 'y': Y.transpose().tolist()}
-        if X.ndim == 1:
-            data['x'] = [data['x']]
-            data['y'] = [data['y']]
-
-        return self._send({
-            'data': data,
-            'win': win,
-            'eid': env,
-            'name': name,
-            'append': append,
-            'opts': opts,
-        }, endpoint='update')
 
     def update_window_opts(self, win, opts, env=None):
         """

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -486,42 +486,6 @@ class UpdateHandler(BaseHandler):
         self.port = app.port
         self.env_path = app.env_path
 
-    # TODO remove when updateTrace is to be deprecated
-    @staticmethod
-    def update_updateTrace(p, args):
-        pdata = p['content']['data']
-
-        new_data = args['data']
-        name = args.get('name')
-        append = args.get('append')
-
-        idxs = list(range(len(pdata)))
-
-        if name is not None:
-            assert len(new_data['x']) == 1
-            idxs = [i for i in idxs if pdata[i]['name'] == name]
-
-        # inject new trace
-        if len(idxs) == 0:
-            idx = len(pdata)
-            pdata.append(dict(pdata[0]))   # plot is not empty, clone an entry
-            pdata[idx]['name'] = name
-            idxs = [idx]
-            append = False
-            if 'marker' in new_data:
-                pdata[idx]['marker']['color'] = new_data['marker']
-
-        for n, idx in enumerate(idxs):    # update traces
-            if all(math.isnan(i) or i is None for i in new_data['x'][n]):
-                continue
-
-            pdata[idx]['x'] = (pdata[idx]['x'] + new_data['x'][n]) if append \
-                else new_data['x'][n]
-            pdata[idx]['y'] = (pdata[idx]['y'] + new_data['y'][n]) if append \
-                else new_data['y'][n]
-
-        return p
-
     @staticmethod
     def update(p, args):
         # Update text in window, separated by a line break
@@ -532,9 +496,6 @@ class UpdateHandler(BaseHandler):
         pdata = p['content']['data']
 
         new_data = args.get('data')
-        # TODO remove when updateTrace is deprecated
-        if isinstance(new_data, dict):
-            return UpdateHandler.update_updateTrace(p, args)
         p = update_window(p, args)
         name = args.get('name')
         if name is None and new_data is None:

--- a/th/init.lua
+++ b/th/init.lua
@@ -295,47 +295,6 @@ M.update_window_opts = argcheck{
    end
 }
 
-M.updateTrace = argcheck{
-   doc = [[
-      This function allows updating of the data of a line or scatter plot.
-
-      It is up to the user to specify `name` of an existing trace if they want
-      to add to it, and a new `name` if they want to add a trace to the plot.
-      By default, if no legend is specified, the `name` is the index of the line
-      in the legend.
-
-      If no `name` is specified, all traces should be updated.
-      Update data that is all NaN is ignored (can be used for masking updates).
-
-      The `append` parameter determines if the update data should be appended to
-      or replaces existing data.
-
-      There are less options because they are assumed to inherited from the
-      specified plot.
-   ]],
-   {name = 'self',         type = 'visdom.client'},
-   {name = 'Y',            type = 'torch.*Tensor'},
-   {name = 'X',            type = 'torch.*Tensor'},
-   {name = 'win',          type = 'string'},
-   {name = 'env',          type = 'string',        opt = true},
-   {name = 'name',         type = 'string',        opt = true},
-   {name = 'append',       type = 'boolean',       opt = true},
-   {name = 'opts',         type = 'table',         opt = true},
-   {name = 'options',      type = 'table',         opt = true},
-   call = function(self, Y, X, win, env, name, append, opts, options)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
-      local args = {X, Y, win}
-      local kwargs = {name = name, append = append, env = env, opts = opts}
-      return self:py_func{func = 'updateTrace', args = args, kwargs = kwargs}
-   end
-}
-
 -- scatter plot:
 M.scatter = argcheck{
    doc = [[


### PR DESCRIPTION
This functionality is no longer supported as we noted a while ago. Removing this allows us to standardize our updates for all plots as they come out