### PR TITLE
options -> opts, removing lua options parameter in favor of opts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Attribution 4.0 International
+Attribution-NonCommercial 4.0 International
 
 =======================================================================
 
@@ -33,7 +33,7 @@ exhaustive, and do not form part of our licenses.
      material not subject to the license. This includes other CC-
      licensed material, or material used under an exception or
      limitation to copyright. More considerations for licensors:
-  wiki.creativecommons.org/Considerations_for_licensors
+	wiki.creativecommons.org/Considerations_for_licensors
 
      Considerations for the public: By using one of our public
      licenses, a licensor grants the public permission to use the
@@ -50,20 +50,22 @@ exhaustive, and do not form part of our licenses.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
      for the public:
-  wiki.creativecommons.org/Considerations_for_licensees
+	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
-Creative Commons Attribution-NonCommercial 4.0 International Public License
+Creative Commons Attribution-NonCommercial 4.0 International Public
+License
 
 By exercising the Licensed Rights (defined below), You accept and agree
-to be bound by the terms and conditions of this Creative Commons Attribution-
-NonCommercial 4.0 International Public License ("Public License"). To the
-extent this Public License may be interpreted as a contract, You are
-granted the Licensed Rights in consideration of Your acceptance of
-these terms and conditions, and the Licensor grants You such rights in
-consideration of benefits the Licensor receives from making the
-Licensed Material available under these terms and conditions.
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
 
 Section 1 -- Definitions.
 
@@ -77,209 +79,211 @@ Section 1 -- Definitions.
      Adapted Material is always produced where the Licensed Material is
      synched in timed relation with a moving image.
 
-b. Adapter's License means the license You apply to Your Copyright
-   and Similar Rights in Your contributions to Adapted Material in
-   accordance with the terms and conditions of this Public License.
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
 
-c. Copyright and Similar Rights means copyright and/or similar rights
-   closely related to copyright including, without limitation,
-   performance, broadcast, sound recording, and Sui Generis Database
-   Rights, without regard to how the rights are labeled or
-   categorized. For purposes of this Public License, the rights
-   specified in Section 2(b)(1)-(2) are not Copyright and Similar
-   Rights.
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
 
-d. Effective Technological Measures means those measures that, in the
-   absence of proper authority, may not be circumvented under laws
-   fulfilling obligations under Article 11 of the WIPO Copyright
-   Treaty adopted on December 20, 1996, and/or similar international
-   agreements.
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
 
-e. Exceptions and Limitations means fair use, fair dealing, and/or
-   any other exception or limitation to Copyright and Similar Rights
-   that applies to Your use of the Licensed Material.
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
 
-f. Licensed Material means the artistic or literary work, database,
-   or other material to which the Licensor applied this Public
-   License.
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
 
-g. Licensed Rights means the rights granted to You subject to the
-   terms and conditions of this Public License, which are limited to
-   all Copyright and Similar Rights that apply to Your use of the
-   Licensed Material and that the Licensor has authority to license.
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
 
-h. Licensor means the individual(s) or entity(ies) granting rights
-   under this Public License.
+  i. NonCommercial means not primarily intended for or directed towards
+     commercial advantage or monetary compensation. For purposes of
+     this Public License, the exchange of the Licensed Material for
+     other material subject to Copyright and Similar Rights by digital
+     file-sharing or similar means is NonCommercial provided there is
+     no payment of monetary compensation in connection with the
+     exchange.
 
-i. NonCommercial means not primarily intended for or directed towards
-   commercial advantage or monetary compensation. For purposes of this
-   Public License, the exchange of the Licensed Material for other material
-   subject to Copyright and Similar Rights by digital file-sharing or
-   similar means is NonCommercial provided there is no payment of monetary
-   compensation in connection with the exchange.
+  j. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
 
-j. Share means to provide material to the public by any means or
-   process that requires permission under the Licensed Rights, such
-   as reproduction, public display, public performance, distribution,
-   dissemination, communication, or importation, and to make material
-   available to the public including in ways that members of the
-   public may access the material from a place and at a time
-   individually chosen by them.
+  k. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
 
-k. Sui Generis Database Rights means rights other than copyright
-   resulting from Directive 96/9/EC of the European Parliament and of
-   the Council of 11 March 1996 on the legal protection of databases,
-   as amended and/or succeeded, as well as other essentially
-   equivalent rights anywhere in the world.
-
-l. You means the individual or entity exercising the Licensed Rights
-   under this Public License. Your has a corresponding meaning.
+  l. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
 
 Section 2 -- Scope.
 
-a. License grant.
+  a. License grant.
 
-     1. Subject to the terms and conditions of this Public License,
-        the Licensor hereby grants You a worldwide, royalty-free,
-        non-sublicensable, non-exclusive, irrevocable license to
-        exercise the Licensed Rights in the Licensed Material to:
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
 
-          a. reproduce and Share the Licensed Material, in whole or
-             in part, for NonCommercial purposes only; and
+            a. reproduce and Share the Licensed Material, in whole or
+               in part, for NonCommercial purposes only; and
 
-          b. produce, reproduce, and Share Adapted Material for
-             NonCommercial purposes only.
+            b. produce, reproduce, and Share Adapted Material for
+               NonCommercial purposes only.
 
-     2. Exceptions and Limitations. For the avoidance of doubt, where
-        Exceptions and Limitations apply to Your use, this Public
-        License does not apply, and You do not need to comply with
-        its terms and conditions.
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
 
-     3. Term. The term of this Public License is specified in Section
-        6(a).
+       3. Term. The term of this Public License is specified in Section
+          6(a).
 
-     4. Media and formats; technical modifications allowed. The
-        Licensor authorizes You to exercise the Licensed Rights in
-        all media and formats whether now known or hereafter created,
-        and to make technical modifications necessary to do so. The
-        Licensor waives and/or agrees not to assert any right or
-        authority to forbid You from making technical modifications
-        necessary to exercise the Licensed Rights, including
-        technical modifications necessary to circumvent Effective
-        Technological Measures. For purposes of this Public License,
-        simply making modifications authorized by this Section 2(a)
-        (4) never produces Adapted Material.
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
 
-     5. Downstream recipients.
+       5. Downstream recipients.
 
-          a. Offer from the Licensor -- Licensed Material. Every
-             recipient of the Licensed Material automatically
-             receives an offer from the Licensor to exercise the
-             Licensed Rights under the terms and conditions of this
-             Public License.
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
 
-          b. No downstream restrictions. You may not offer or impose
-             any additional or different terms or conditions on, or
-             apply any Effective Technological Measures to, the
-             Licensed Material if doing so restricts exercise of the
-             Licensed Rights by any recipient of the Licensed
-             Material.
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
 
-     6. No endorsement. Nothing in this Public License constitutes or
-        may be construed as permission to assert or imply that You
-        are, or that Your use of the Licensed Material is, connected
-        with, or sponsored, endorsed, or granted official status by,
-        the Licensor or others designated to receive attribution as
-        provided in Section 3(a)(1)(A)(i).
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
 
-b. Other rights.
+  b. Other rights.
 
-     1. Moral rights, such as the right of integrity, are not
-        licensed under this Public License, nor are publicity,
-        privacy, and/or other similar personality rights; however, to
-        the extent possible, the Licensor waives and/or agrees not to
-        assert any such rights held by the Licensor to the limited
-        extent necessary to allow You to exercise the Licensed
-        Rights, but not otherwise.
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
 
-     2. Patent and trademark rights are not licensed under this
-        Public License.
+       2. Patent and trademark rights are not licensed under this
+          Public License.
 
-     3. To the extent possible, the Licensor waives any right to
-        collect royalties from You for the exercise of the Licensed
-        Rights, whether directly or through a collecting society
-        under any voluntary or waivable statutory or compulsory
-        licensing scheme. In all other cases the Licensor expressly
-        reserves any right to collect such royalties, including when
-        the Licensed Material is used other than for NonCommercial purposes.
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties, including when
+          the Licensed Material is used other than for NonCommercial
+          purposes.
 
 Section 3 -- License Conditions.
 
 Your exercise of the Licensed Rights is expressly made subject to the
 following conditions.
 
-a. Attribution.
+  a. Attribution.
 
-     1. If You Share the Licensed Material (including in modified
-        form), You must:
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
 
-          a. retain the following if it is supplied by the Licensor
-             with the Licensed Material:
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
 
-               i. identification of the creator(s) of the Licensed
-                  Material and any others designated to receive
-                  attribution, in any reasonable manner requested by
-                  the Licensor (including by pseudonym if
-                  designated);
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
 
-              ii. a copyright notice;
+                ii. a copyright notice;
 
-             iii. a notice that refers to this Public License;
+               iii. a notice that refers to this Public License;
 
-              iv. a notice that refers to the disclaimer of
-                  warranties;
+                iv. a notice that refers to the disclaimer of
+                    warranties;
 
-               v. a URI or hyperlink to the Licensed Material to the
-                  extent reasonably practicable;
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
 
-          b. indicate if You modified the Licensed Material and
-             retain an indication of any previous modifications; and
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
 
-          c. indicate the Licensed Material is licensed under this
-             Public License, and include the text of, or the URI or
-             hyperlink to, this Public License.
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
 
-     2. You may satisfy the conditions in Section 3(a)(1) in any
-        reasonable manner based on the medium, means, and context in
-        which You Share the Licensed Material. For example, it may be
-        reasonable to satisfy the conditions by providing a URI or
-        hyperlink to a resource that includes the required
-        information.
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
 
-     3. If requested by the Licensor, You must remove any of the
-        information required by Section 3(a)(1)(A) to the extent
-        reasonably practicable.
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
 
-     4. If You Share Adapted Material You produce, the Adapter's
-        License You apply must not prevent recipients of the Adapted
-        Material from complying with this Public License.
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
 
 Section 4 -- Sui Generis Database Rights.
 
 Where the Licensed Rights include Sui Generis Database Rights that
 apply to Your use of the Licensed Material:
 
-a. for the avoidance of doubt, Section 2(a)(1) grants You the right to
-   extract, reuse, reproduce, and Share all or a substantial portion of
-   the contents of the database for NonCommercial purposes only;
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database for NonCommercial purposes
+     only;
 
-b. if You include all or a substantial portion of the database
-   contents in a database in which You have Sui Generis Database
-   Rights, then the database in which You have Sui Generis Database
-   Rights (but not its individual contents) is Adapted Material; and
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
 
-c. You must comply with the conditions in Section 3(a) if You Share
-   all or a substantial portion of the contents of the database.
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
 
 For the avoidance of doubt, this Section 4 supplements and does not
 replace Your obligations under this Public License where the Licensed
@@ -287,99 +291,101 @@ Rights include other Copyright and Similar Rights.
 
 Section 5 -- Disclaimer of Warranties and Limitation of Liability.
 
-a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
-   EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
-   AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
-   ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
-   IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
-   WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
-   PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
-   ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
-   KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
-   ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
 
-b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
-   TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
-   NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
-   INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
-   COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
-   USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
-   ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
-   DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
-   IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
 
-c. The disclaimer of warranties and limitation of liability provided
-   above shall be interpreted in a manner that, to the extent
-   possible, most closely approximates an absolute disclaimer and
-   waiver of all liability.
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
 
 Section 6 -- Term and Termination.
 
-a. This Public License applies for the term of the Copyright and
-   Similar Rights licensed here. However, if You fail to comply with
-   this Public License, then Your rights under this Public License
-   terminate automatically.
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
 
-b. Where Your right to use the Licensed Material has terminated under
-   Section 6(a), it reinstates:
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
 
-     1. automatically as of the date the violation is cured, provided
-        it is cured within 30 days of Your discovery of the
-        violation; or
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
 
-     2. upon express reinstatement by the Licensor.
+       2. upon express reinstatement by the Licensor.
 
-   For the avoidance of doubt, this Section 6(b) does not affect any
-   right the Licensor may have to seek remedies for Your violations
-   of this Public License.
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
 
-c. For the avoidance of doubt, the Licensor may also offer the
-   Licensed Material under separate terms or conditions or stop
-   distributing the Licensed Material at any time; however, doing so
-   will not terminate this Public License.
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
 
-d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
-   License.
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
 
 Section 7 -- Other Terms and Conditions.
 
-a. The Licensor shall not be bound by any additional or different
-   terms or conditions communicated by You unless expressly agreed.
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
 
-b. Any arrangements, understandings, or agreements regarding the
-   Licensed Material not stated herein are separate from and
-   independent of the terms and conditions of this Public License.
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
 
 Section 8 -- Interpretation.
 
-a. For the avoidance of doubt, this Public License does not, and
-   shall not be interpreted to, reduce, limit, restrict, or impose
-   conditions on any use of the Licensed Material that could lawfully
-   be made without permission under this Public License.
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
 
-b. To the extent possible, if any provision of this Public License is
-   deemed unenforceable, it shall be automatically reformed to the
-   minimum extent necessary to make it enforceable. If the provision
-   cannot be reformed, it shall be severed from this Public License
-   without affecting the enforceability of the remaining terms and
-   conditions.
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
 
-c. No term or condition of this Public License will be waived and no
-   failure to comply consented to unless expressly agreed to by the
-   Licensor.
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
 
-d. Nothing in this Public License constitutes or may be interpreted
-   as a limitation upon, or waiver of, any privileges and immunities
-   that apply to the Licensor or You, including from the legal
-   processes of any jurisdiction or authority.
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
 
 =======================================================================
 
-Creative Commons is not a party to its public licenses.
-Notwithstanding, Creative Commons may elect to apply one of its public
-licenses to material it publishes and in those instances will be
-considered the "Licensor." Except for the limited purpose of indicating
-that material is shared under a Creative Commons public license or as
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
 otherwise permitted by the Creative Commons policies published at
 creativecommons.org/policies, Creative Commons does not authorize the
 use of the trademark "Creative Commons" or any other trademark or logo
@@ -387,7 +393,7 @@ of Creative Commons without its prior written consent including,
 without limitation, in connection with any unauthorized modifications
 to any of its public licenses or any other arrangements,
 understandings, or agreements concerning use of licensed material. For
-the avoidance of doubt, this paragraph does not form part of the public
-licenses.
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
 
 Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can partition your visualization space with `envs`. By default, every user w
 
 You can access a specific env via url: `http://localhost.com:8097/env/main`. If your server is hosted, you can share this url so others can see your visualizations too.
 
-Environments are automatically hierarchically organized by the first `_`. 
+Environments are automatically hierarchically organized by the first `_`.
 
 #### Selecting Environments
 <p align="center"><img align="center" src="https://user-images.githubusercontent.com/1276867/34618242-261d55d4-f20c-11e7-820d-c16731248b26.png" width="300" /></p>

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -488,7 +488,7 @@ class Visdom(object):
         """
         This function draws an SVG object. It takes as input an SVG string or the
         name of an SVG file. The function does not support any plot-specific
-        `options`.
+        `opts`.
         """
         opts = {} if opts is None else opts
         _assert_opts(opts)
@@ -736,7 +736,7 @@ class Visdom(object):
         The `append` parameter determines if the update data should be appended
         to or replaces existing data.
 
-        There are less options because they are assumed to inherited from the
+        There are less opts because they are assumed to inherited from the
         specified plot.
         """
         warnings.warn("updateTrace is going to be deprecated in the next "
@@ -1268,7 +1268,7 @@ class Visdom(object):
         tensors `gridX` and `gridY` can be provided that specify the offsets of
         the arrows; by default, the arrows will be done on a regular grid.
 
-        The following `options` are supported:
+        The following `opts` are supported:
 
         - `opts.normalize`:  length of longest arrows (`number`)
         - `opts.arrowheads`: show arrow heads (`boolean`; default = `true`)
@@ -1392,7 +1392,7 @@ class Visdom(object):
         """
         This function draws a pie chart based on the `N` tensor `X`.
 
-        The following `options` are supported:
+        The following `opts` are supported:
 
         - `opts.legend`: `table` containing legend names
         """
@@ -1424,7 +1424,7 @@ class Visdom(object):
         `Nx2` or `Nx3` matrix `X`, and polygons defined in an optional `Mx2` or
         `Mx3` matrix `Y`.
 
-        The following `options` are supported:
+        The following `opts` are supported:
 
         - `opts.color`: color (`string`)
         - `opts.opacity`: opacity of polygons (`number` between 0 and 1)

--- a/th/init.lua
+++ b/th/init.lua
@@ -22,54 +22,6 @@ local argcheck = require 'argcheck'
 local visdom = {}
 local M = torch.class('visdom.client', visdom)
 
--- function that performs assertions on options:
-local assertOptions = argcheck{
-   {name = 'options', type = 'table'},
-   call = function(options)
-      if options.colormap then
-         assert(type(options.colormap) == 'string', 'colormap should be string')
-      end
-      if options.color then
-         assert(type(options.color) == 'string', 'color should be string')
-      end
-      if options.mode then
-         assert(type(options.mode) == 'string', 'mode should be a string')
-      end
-      if options.markersymbol then
-         assert(type(options.markersymbol) == 'string',
-            'marker symbol should be string')
-      end
-      if options.markersize then
-         assert(type(options.markersize) == 'number' or options.markersize > 0,
-            'marker size should be a positive number')
-      end
-      if options.columnnames then
-         assert(type(options.columnnames) == 'table',
-            'columnnames should be a table with column names')
-      end
-      if options.rownames then
-         assert(type(options.rownames) == 'table',
-            'rownames should be a table with row names')
-      end
-      if options.jpgquality then
-         assert(type(options.jpgquality) == 'number',
-            'JPG quality should be a number')
-         assert(options.jpgquality > 0 and options.jpgquality <= 100,
-            'JPG quality should be number between 0 and 100')
-      end
-      if options.fps then
-         assert(type(options.fps) == 'number', 'fps should be a number')
-         assert(options.fps > 0 , 'fps should be greater than zero')
-      end
-      if options.opacity then
-         assert(type(options.opacity) == 'number',
-            'opacity should be a number')
-         assert(options.opacity >= 0 and options.opacity <= 1,
-            'opacity should be a number between 0 and 1')
-      end
-   end
-}
-
 -- initialize plotting object:
 M.__init = argcheck{
    doc = [[
@@ -113,34 +65,34 @@ M.__init = argcheck{
       `win` of the window it plotted in. One can also specify the `env`, (a
        workspace id), to which the visualization should be added.
 
-      In addition, the plotting functions take an optional `options` table as
+      In addition, the plotting functions take an optional `opts` table as
       input that can be used to change (generic or plot-specific) properties of
       the plots. All input arguments are specified in a single table; the input
       arguments are matches based on the keys they have in the input table.
 
-      The following `options` are generic in the sense that they are the same
+      The following `opts` are generic in the sense that they are the same
       for all visualizations (except `plot.image` and `plot.text`):
 
-      - `options.title`       : figure title
-      - `options.width`       : figure width
-      - `options.height`      : figure height
-      - `options.showlegend`  : show legend (`true` or `false`)
-      - `options.xtype`       : type of x-axis (`'linear'` or `'log'`)
-      - `options.xlabel`      : label of x-axis
-      - `options.xtick`       : show ticks on x-axis (`boolean`)
-      - `options.xtickmin`    : first tick on x-axis (`number`)
-      - `options.xtickmax`    : last tick on x-axis (`number`)
-      - `options.xtickstep`   : distances between ticks on x-axis (`number`)
-      - `options.ytype`       : type of y-axis (`'linear'` or `'log'`)
-      - `options.ylabel`      : label of y-axis
-      - `options.ytick`       : show ticks on y-axis (`boolean`)
-      - `options.ytickmin`    : first tick on y-axis (`number`)
-      - `options.ytickmax`    : last tick on y-axis (`number`)
-      - `options.ytickstep`   : distances between ticks on y-axis (`number`)
-      - `options.marginleft`  : left margin (in pixels)
-      - `options.marginright` : right margin (in pixels)
-      - `options.margintop`   : top margin (in pixels)
-      - `options.marginbottom`: bottom margin (in pixels)
+      - `opts.title`       : figure title
+      - `opts.width`       : figure width
+      - `opts.height`      : figure height
+      - `opts.showlegend`  : show legend (`true` or `false`)
+      - `opts.xtype`       : type of x-axis (`'linear'` or `'log'`)
+      - `opts.xlabel`      : label of x-axis
+      - `opts.xtick`       : show ticks on x-axis (`boolean`)
+      - `opts.xtickmin`    : first tick on x-axis (`number`)
+      - `opts.xtickmax`    : last tick on x-axis (`number`)
+      - `opts.xtickstep`   : distances between ticks on x-axis (`number`)
+      - `opts.ytype`       : type of y-axis (`'linear'` or `'log'`)
+      - `opts.ylabel`      : label of y-axis
+      - `opts.ytick`       : show ticks on y-axis (`boolean`)
+      - `opts.ytickmin`    : first tick on y-axis (`number`)
+      - `opts.ytickmax`    : last tick on y-axis (`number`)
+      - `opts.ytickstep`   : distances between ticks on y-axis (`number`)
+      - `opts.marginleft`  : left margin (in pixels)
+      - `opts.marginright` : right margin (in pixels)
+      - `opts.margintop`   : top margin (in pixels)
+      - `opts.marginbottom`: bottom margin (in pixels)
 
       The other options are visualization-specific, and are described in the
       documentation of the functions.
@@ -351,13 +303,13 @@ M.scatter = argcheck{
       Use `name` if you want to update a specific trace.
       Update data that is all NaN is ignored (can be used for masking updates).
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-       - `options.colormap`    : colormap (`string`; default = `'Viridis'`)
-       - `options.markersymbol`: marker symbol (`string`; default = `'dot'`)
-       - `options.markersize`  : marker size (`number`; default = `'10'`)
-       - `options.markercolor` : marker color (`torch.*Tensor`; default = `nil`)
-       - `options.legend`      : `table` containing legend names
+       - `opts.colormap`    : colormap (`string`; default = `'Viridis'`)
+       - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
+       - `opts.markersize`  : marker size (`number`; default = `'10'`)
+       - `opts.markercolor` : marker color (`torch.*Tensor`; default = `nil`)
+       - `opts.legend`      : `table` containing legend names
        - `opts.textlabels`    : text label for each point (table: default = `nil`)
    ]],
    noordered = true,
@@ -365,19 +317,12 @@ M.scatter = argcheck{
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'Y',       type = 'torch.*Tensor', opt = true},
    {name = 'opts',    type = 'table',         opt = true},
-   {name = 'options', type = 'table',         opt = true},
    {name = 'win',     type = 'string',        opt = true},
    {name = 'env',     type = 'string',        opt = true},
    {name = 'update',  type = 'string',        opt = true},
    {name = 'name',    type = 'string',        opt = true},
-   call = function(self, X, Y, opts, options, win, env, update)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, Y, opts, win, env, update)
+      opts = opts or {}
       local args = {X}
       local kwargs = {
          Y = Y,
@@ -406,32 +351,25 @@ M.line = argcheck{
       Use `name` if you want to update a specific trace.
       Update data that is all NaN is ignored (can be used for masking updates).
 
-      The following `options` are supported:
-       - `options.fillarea`    : fill area below line (`boolean`)
-       - `options.colormap`    : colormap (`string`; default = `'Viridis'`)
-       - `options.markers`     : show markers (`boolean`; default = `false`)
-       - `options.markersymbol`: marker symbol (`string`; default = `'dot'`)
-       - `options.markersize`  : marker size (`number`; default = `'10'`)
-       - `options.legend`      : `table` containing legend names
+      The following `opts` are supported:
+       - `opts.fillarea`    : fill area below line (`boolean`)
+       - `opts.colormap`    : colormap (`string`; default = `'Viridis'`)
+       - `opts.markers`     : show markers (`boolean`; default = `false`)
+       - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
+       - `opts.markersize`  : marker size (`number`; default = `'10'`)
+       - `opts.legend`      : `table` containing legend names
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'Y',       type = 'torch.*Tensor'},
    {name = 'X',       type = 'torch.*Tensor', opt = true},
    {name = 'opts',    type = 'table',         opt = true},
-   {name = 'options', type = 'table',         opt = true},
    {name = 'win',     type = 'string',        opt = true},
    {name = 'env',     type = 'string',        opt = true},
    {name = 'update',  type = 'string',        opt = true},
    {name = 'name',    type = 'string',        opt = true},
-   call = function(self, Y, X, opts, options, win, env, update)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, Y, X, opts, win, env, update)
+      opts = opts or {}
       local args = {Y}
       local kwargs = {
          X = X,
@@ -454,27 +392,20 @@ M.stem = argcheck{
       as well; if `Y` is an `N` tensor then all `M` time series are assumed to
       have the same timestamps.
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-       - `options.colormap`: colormap (`string`; default = `'Viridis'`)
-       - `options.legend`  : `table` containing legend names
+       - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
+       - `opts.legend`  : `table` containing legend names
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'Y',       type = 'torch.*Tensor', opt = true},
    {name = 'opts',    type = 'table',         opt = true},
-   {name = 'options', type = 'table',         opt = true},
    {name = 'win',     type = 'string',        opt = true},
    {name = 'env',     type = 'string',        opt = true},
-   call = function(self, X, Y, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, Y, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {Y = Y, win = win, env = env, opts = opts}
       return self:py_func{func = 'stem', args = args, kwargs = kwargs}
@@ -487,29 +418,22 @@ M.heatmap = argcheck{
       This function draws a heatmap. It takes as input an `NxM` tensor `X` that
       specifies the value at each location in the heatmap.
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-       - `options.colormap`: colormap (`string`; default = `'Viridis'`)
-       - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
-       - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
-       - `options.columnnames`: `table` containing x-axis labels
-       - `options.rownames`: `table` containing y-axis labels
+       - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
+       - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
+       - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
+       - `opts.columnnames`: `table` containing x-axis labels
+       - `opts.rownames`: `table` containing y-axis labels
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, X, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {win = win, env = env, opts = opts}
       return self:py_func{func = 'heatmap', args = args, kwargs = kwargs}
@@ -522,32 +446,25 @@ M.bar = argcheck{
       This function draws a regular, stacked, or grouped bar plot. It takes as
       input an `N` or `NxM` tensor `X` that specifies the height of each of the
       bars. If `X` contains `M` columns, the values corresponding to each row
-      are either stacked or grouped (dependending on how `options.stacked` is
+      are either stacked or grouped (dependending on how `opts.stacked` is
       set). In addition to `X`, an (optional) `N` tensor `Y` can be specified
       that contains the corresponding x-axis values.
 
-      The following plot-specific `options` are currently supported:
+      The following plot-specific `opts` are currently supported:
 
-       - `options.rownames`: `table` containing x-axis labels
-       - `options.stacked` : stack multiple columns in `X`
-       - `options.legend`  : `table` containing legend labels
+       - `opts.rownames`: `table` containing x-axis labels
+       - `opts.stacked` : stack multiple columns in `X`
+       - `opts.legend`  : `table` containing legend labels
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'Y',       type = 'torch.*Tensor', opt = true},
    {name = 'opts',    type = 'table',         opt = true},
-   {name = 'options', type = 'table',         opt = true},
    {name = 'win',     type = 'string',        opt = true},
    {name = 'env',     type = 'string',        opt = true},
-   call = function(self, X, Y, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, Y, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {Y = Y, win = win, env = env, opts = opts}
       return self:py_func{func = 'bar', args = args, kwargs = kwargs}
@@ -561,25 +478,18 @@ M.histogram = argcheck{
       an `N` tensor `X` that specifies the data of which to construct the
       histogram.
 
-      The following plot-specific `options` are currently supported:
+      The following plot-specific `opts` are currently supported:
 
-       - `options.numbins`: number of bins (`number`; default = 30)
+       - `opts.numbins`: number of bins (`number`; default = 30)
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, X, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {win = win, env = env, opts = opts}
       return self:py_func{func = 'histogram', args = args, kwargs = kwargs}
@@ -593,25 +503,18 @@ M.boxplot = argcheck{
       an `N` or an `NxM` tensor `X` that specifies the `N` data values of which
       to construct the `M` boxplots.
 
-      The following plot-specific `options` are currently supported:
+      The following plot-specific `opts` are currently supported:
 
-       - `options.legend`: labels for each of the columns in `X`
+       - `opts.legend`: labels for each of the columns in `X`
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, X, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {win = win, env = env, opts = opts}
       return self:py_func{func = 'boxplot', args = args, kwargs = kwargs}
@@ -624,27 +527,20 @@ M.surf = argcheck{
       This function draws a surface plot. It takes as input an `NxM` tensor `X`
       that specifies the value at each location in the surface plot.
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-       - `options.colormap`: colormap (`string`; default = `'Viridis'`)
-       - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
-       - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
+       - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
+       - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
+       - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, X, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {win = win, env = env, opts = opts}
       return self:py_func{func = 'surf', args = args, kwargs = kwargs}
@@ -657,27 +553,20 @@ M.contour = argcheck{
       This function draws a contour plot. It takes as input an `NxM` tensor `X`
       that specifies the value at each location in the contour plot.
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-       - `options.colormap`: colormap (`string`; default = `'Viridis'`)
-       - `options.xmin`    : clip minimum value (`number`; default = `X:min()`)
-       - `options.xmax`    : clip maximum value (`number`; default = `X:max()`)
+       - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
+       - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
+       - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, X, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {win = win, env = env, opts = opts}
       return self:py_func{func = 'contour', args = args, kwargs = kwargs}
@@ -692,10 +581,10 @@ M.quiver = argcheck{
       tensors `gridX` and `gridY` can be provided that specify the offsets of
       the arrows; by default, the arrows will be done on a regular grid.
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-       - `options.normalize`:  length of longest arrows (`number`)
-       - `options.arrowheads`: show arrow heads (`boolean`; default = `true`)
+       - `opts.normalize`:  length of longest arrows (`number`)
+       - `opts.arrowheads`: show arrow heads (`boolean`; default = `true`)
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
@@ -704,17 +593,10 @@ M.quiver = argcheck{
    {name = 'gridX',   type = 'torch.*Tensor', opt = true},
    {name = 'gridY',   type = 'torch.*Tensor', opt = true},
    {name = 'opts',    type = 'table',         opt = true},
-   {name = 'options', type = 'table',         opt = true},
    {name = 'win',     type = 'string',        opt = true},
    {name = 'env',     type = 'string',        opt = true},
-   call = function(self, X, Y, gridX, gridY, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, Y, gridX, gridY, opts, win, env)
+      opts = opts or {}
       local args = {X, Y}
       local kwargs = {
          gridX = gridX,
@@ -732,25 +614,18 @@ M.pie = argcheck{
    doc = [[
       This function draws a pie chart based on the `N` tensor `X`.
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-       - `options.legend`: `table` containing legend names
+       - `opts.legend`: `table` containing legend names
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, X, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {win = win, env = env, opts = opts}
       return self:py_func{func = 'pie', args = args, kwargs = kwargs}
@@ -764,26 +639,19 @@ M.mesh = argcheck{
       `Nx2` or `Nx3` matrix `X`, and polygons defined in an optional `Mx2` or
       `Mx3` matrix `Y`.
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-      - `options.color`: color (`string`)
-      - `options.opacity`: opacity of polygons (`number` between 0 and 1)
+      - `opts.color`: color (`string`)
+      - `opts.opacity`: opacity of polygons (`number` between 0 and 1)
    ]],
    {name = 'self',    type = 'visdom.client'},
    {name = 'X',       type = 'torch.*Tensor'},
    {name = 'Y',       type = 'torch.*Tensor', opt = true},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, X, Y, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, X, Y, opts, win, env)
+      opts = opts or {}
       local args = {X}
       local kwargs = {Y = Y, win = win, env = env, opts = opts}
       return self:py_func{func = 'mesh', args = args, kwargs = kwargs}
@@ -796,25 +664,18 @@ M.image = argcheck{
       This function draws an img. It takes as input an `CxHxW` tensor `img`
       that contains the image.
 
-      The following `options` are supported:
+      The following `opts` are supported:
 
-       - `options.jpgquality`: JPG quality (`number` 0-100; default = 100)
+       - `opts.jpgquality`: JPG quality (`number` 0-100; default = 100)
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'img',     type = 'torch.*Tensor'},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, img, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, img, opts, win, env)
+      opts = opts or {}
       local args = {img}
       local kwargs = {win = win, env = env, opts = opts}
       return self:py_func{func = 'image', args = args, kwargs = kwargs}
@@ -837,17 +698,10 @@ M.images = argcheck{
    {name = 'nrow',    type = 'number', opt = true},
    {name = 'padding', type = 'number', opt = true},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, table, tensor, nrow, padding, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, table, tensor, nrow, padding, opts, win, env)
+      opts = opts or {}
       assert(table or tensor)
       local input = table or tensor
       local args = {input}
@@ -867,24 +721,17 @@ M.svg = argcheck{
    doc = [[
       This function draws an SVG object. It takes as input an SVG string or the
       name of an SVG file. The function does not support any plot-specific
-      `options`.
+      `opts`.
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'svgstr',  type = 'string', opt = true},
    {name = 'svgfile', type = 'string', opt = true},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
-   call = function(self, svgstr, svgfile, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, svgstr, svgfile, opts, win, env)
+      opts = opts or {}
       local args = {}
       local kwargs = {
          svgstr = svgstr,
@@ -913,17 +760,10 @@ M.audio = argcheck{
    {name = 'tensor',    type = 'torch.*Tensor', opt = true},
    {name = 'audiofile', type = 'string', opt = true},
    {name = 'opts',      type = 'table',  opt = true},
-   {name = 'options',   type = 'table',  opt = true},
    {name = 'win',       type = 'string', opt = true},
    {name = 'env',       type = 'string', opt = true},
-   call = function(self, tensor, audiofile, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, tensor, audiofile, opts, win, env)
+      opts = opts or {}
       local args = {}
       local kwargs = {
          tensor = tensor,
@@ -952,17 +792,10 @@ M.video = argcheck{
    {name = 'tensor',    type = 'torch.ByteTensor', opt = true},
    {name = 'videofile', type = 'string', opt = true},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options',   type = 'table',  opt = true},
    {name = 'win',       type = 'string', opt = true},
    {name = 'env',       type = 'string', opt = true},
-   call = function(self, tensor, videofile, opts, options, win, env)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, tensor, videofile, opts, win, env)
+      opts = opts or {}
       local args = {}
       local kwargs = {
          tensor = tensor,
@@ -979,24 +812,17 @@ M.video = argcheck{
 M.text = argcheck{
    doc = [[
       This function prints text in a box. It takes as input an `text` string.
-      No specific `options` are currently supported.
+      No specific `opts` are currently supported.
    ]],
    noordered = true,
    {name = 'self',    type = 'visdom.client'},
    {name = 'text',    type = 'string'},
    {name = 'opts',    type = 'table',  opt = true},
-   {name = 'options', type = 'table',  opt = true},
    {name = 'win',     type = 'string', opt = true},
    {name = 'env',     type = 'string', opt = true},
    {name = 'append',  type = 'boolean', opt = true},
-   call = function(self, text, opts, options, win, env, append)
-      if options then
-         print(
-            [[WARNING: Argument `options` is deprecated and will soon be
-            removed. Use argument `opts` instead.]]
-         )
-      end
-      opts = opts or options or {}
+   call = function(self, text, opts, win, env, append)
+      opts = opts or {}
       local args = {text}
       local kwargs = {win = win, env = env, opts = opts, append = append}
       return self:py_func{func = 'text', args = args, kwargs = kwargs}
@@ -1065,10 +891,6 @@ M.py_func = argcheck {
 
      for k,v in pairs(kwargs or {}) do
        kwargs[k] = prep(v)
-       if k == 'options' then
-         kwargs.opts = kwargs.options
-         kwargs.options = nil
-       end
      end
 
      local ret = self:sendRequest{


### PR DESCRIPTION
We initially requested that users switch to using the `opts` parameter, but now we deprecate using `options` entirely in order to clean up the code.

Doesn't remove options from updateTrace, as that is being completely removed in https://github.com/facebookresearch/visdom/pull/342 and I don't want merge conflicts.