### PR TITLE
textlabels bugs in scatter?

### DIFF
--- a/example/demo.py
+++ b/example/demo.py
@@ -186,6 +186,14 @@ try:
             textlabels=['Label %d' % (i + 1) for i in range(10)]
         )
     )
+    viz.scatter(
+        X=np.random.rand(10, 2),
+        Y=[1] * 5 + [2] * 3 + [3] * 2,
+        opts=dict(
+            legend=['A', 'B', 'C'],
+            textlabels=['Label %d' % (i + 1) for i in range(10)]
+        )
+    )
 
     # bar plots
     viz.bar(X=np.random.rand(20))

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -873,6 +873,12 @@ class Visdom(object):
             opts['markercolor'] = _markerColorCheck(
                 opts['markercolor'], X, Y, K)
 
+        L = opts.get('textlabels')
+        if L is not None:
+            L = np.squeeze(L)
+            assert len(L) == X.shape[0], \
+                'textlabels and X should have same shape'
+
         _assert_opts(opts)
 
         if opts.get('legend'):
@@ -896,7 +902,7 @@ class Visdom(object):
                     'name': trace_name,
                     'type': 'scatter3d' if is3d else 'scatter',
                     'mode': opts.get('mode'),
-                    'text': opts.get('textlabels'),
+                    'text': L[ind].tolist() if L is not None else None,
                     'textposition': 'right',
                     'marker': {
                         'size': opts.get('markersize'),


### PR DESCRIPTION
When `Y` is set, `textlabels` not works expectedly.