### PR TITLE
Don't use incoming socket in Visdom instance on server

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -410,7 +410,9 @@ class PostHandler(BaseHandler):
         self.sources = app.sources
         self.port = app.port
         self.env_path = app.env_path
-        self.vis = visdom.Visdom(port=self.port, send=False)
+        self.vis = visdom.Visdom(
+            port=self.port, send=False, use_incoming_socket=False
+        )
         self.handlers = {
             'update': UpdateHandler,
             'save': SaveHandler,


### PR DESCRIPTION
When called with the default argument (`True`), this introduces a quite noticeable delay (and error message) for every post to the server.

Fixes #354