### PR TITLE
Add pillow-simd as requirement if it is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
 import os
 from setuptools import setup
+from pkg_resources import get_distribution, DistributionNotFound
+
+
+def get_dist(pkgname):
+    try:
+        return get_distribution(pkgname)
+    except DistributionNotFound:
+        return None
+
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -11,7 +20,6 @@ readme = open('README.md').read()
 requirements = [
     'numpy>=1.8',
     'scipy',
-    'pillow',
     'requests',
     'tornado',
     'pyzmq',
@@ -19,6 +27,8 @@ requirements = [
     'torchfile',
     'websocket-client',
 ]
+pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
+requirements.append(pillow_req)
 
 setup(
     # Metadata


### PR DESCRIPTION
As discussed in #367, this PR allows visdom to work with Pillow-simd if the end user has it installed.  
What this PR does, is that upon installation it checks if pillow-simd is installed and adds it to the requirements if it is. Otherwise, regular pillow is added.  
Pillow-simd is a drop-in replacement that uses the same namespace, so no further changes are required.

__Disclaimer:__  
I did not figure this one out on my own, but saw this solution in [pytorch/vision](https://github.com/pytorch/vision/pull/522).
This solution might have some problems I am not aware of, as I am no guru when working with setuptools. One thing I do know, is that this will cause a problem when creating pip wheels, so that should be taken into consideration. _(I dont think that this is a concern for this project)_