### PR TITLE
Registering Delete Env Handler

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -154,7 +154,7 @@ class Application(tornado.web.Application):
             (r"/error/(.*)", ErrorHandler, {'app': self}),
             (r"/win_exists", ExistsHandler, {'app': self}),
             (r"/win_data", DataHandler, {'app': self}),
-            (r"/delete_env/", DeleteEnvHandler, {'app': self}),
+            (r"/delete_env", DeleteEnvHandler, {'app': self}),
             (r"/(.*)", IndexHandler, {'app': self}),
         ]
         super(Application, self).__init__(handlers, **tornado_settings)

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -154,6 +154,7 @@ class Application(tornado.web.Application):
             (r"/error/(.*)", ErrorHandler, {'app': self}),
             (r"/win_exists", ExistsHandler, {'app': self}),
             (r"/win_data", DataHandler, {'app': self}),
+            (r"/delete_env/", DeleteEnvHandler, {'app': self}),
             (r"/(.*)", IndexHandler, {'app': self}),
         ]
         super(Application, self).__init__(handlers, **tornado_settings)


### PR DESCRIPTION
Realized in #65 that I had forgotten to register the delete_env handler, which meant that `delete_env` did nothing. Now it actually removes an environment programmatically (tested).