### PR TITLE
Creates default env if it doesn't exist with Visdom(env=...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,11 @@ vis._send({'data': [trace], 'layout': layout, 'win': 'mywin'})
 
 ### Others
 - [`vis.close`](#visclose)    : close a window by id
+- [`vis.delete_env`](#visdelete_env) : delete an environment by env_id
 - [`vis.win_exists`](#viswin_exists) : check if a window already exists by id
 - [`vis.get_window_data`](#visget_window_data): get current data for a window
 - [`vis.check_connection`](#vischeck_connection): check if the server is connected
+
 
 ## Details
 ![visdom_big](https://lh3.googleusercontent.com/-bqH9UXCw-BE/WL2UsdrrbAI/AAAAAAAAnYc/emrxwCmnrW4_CLTyyUttB0SYRJ-i4CCiQCLcB/s0/Screen+Shot+2017-03-06+at+10.51.02+AM.png"visdom_big")
@@ -321,11 +323,11 @@ Supported types:
  - text: string
  - number: decimal number
  - button: button labeled with "value"
- - checkbox: boolean value rendered as a checkbox 
+ - checkbox: boolean value rendered as a checkbox
  - select: multiple values select box
     - `value`: id of selected value (zero based)
     - `values`: list of possible values
- 
+
 Callback are called on property value update:
  - `event_type`: `"PropertyUpdate"`
  - `propertyId`: position in the `properties` list
@@ -578,6 +580,13 @@ documentation of the functions.
 #### vis.close
 
 This function closes a specific window. It takes input window id `win` and environment id `eid`. Use `win` as `None` to close all windows in an environment.
+
+#### vis.delete_env
+
+This function deletes a specified env entirely. It takes env id `eid` as input.
+
+> **Note**: `delete_env` is deletes all data for an environment and is IRREVERSIBLE. Do not use unless you absolutely want to remove an environment.
+
 
 #### vis.win_exists
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -301,6 +301,10 @@ class Visdom(object):
         except ImportError:
             pass
 
+        self._send({
+            'eid': env,
+        }, endpoint='env/' + env)
+
         # when talking to a server, get a backchannel
         if send and use_incoming_socket:
             self.setup_socket()

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -671,7 +671,6 @@ class DeleteEnvHandler(BaseHandler):
 
 def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
     """ load an environment to a client by socket """
-
     env = {}
     if eid in state:
         env = state.get(eid)
@@ -834,12 +833,19 @@ class EnvHandler(BaseHandler):
         )
 
     def post(self, args):
-        sid = tornado.escape.json_decode(
+        msg_args = tornado.escape.json_decode(
             tornado.escape.to_basestring(self.request.body)
-        )['sid']
-        if sid in self.subs:
-            load_env(self.state, args, self.subs[sid], env_path=self.env_path)
-
+        )
+        if 'sid' in msg_args:
+            sid = msg_args['sid']
+            if sid in self.subs:
+                load_env(self.state, args, self.subs[sid],
+                         env_path=self.env_path)
+        if 'eid' in msg_args:
+            eid = msg_args['eid']
+            if eid not in self.state:
+                self.state[eid] = {'jsons': {}, 'reload': {}}
+                broadcast_envs(self)
 
 class CompareHandler(BaseHandler):
     def initialize(self, app):


### PR DESCRIPTION
Right now the env is only created once the visdom client actually posts something, which is somewhat unexpected behavior. Now if an env with `env_name` doesn't exist when `visdom.Visdom(env='env_name')` is called, an env is created for `env_name`.

Fixes #365