### PR TITLE
Allowing updates to custom plots

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -602,7 +602,7 @@ class UpdateHandler(BaseHandler):
 
         if not (p['type'] == 'text' or
                 p['content']['data'][0]['type'] in ['scatter', 'custom']):
-            handler.write('win is not scatter or text, was {}'.format(
+            handler.write('win is not scatter, custom, or text; was {}'.format(
                 p['content']['data'][0]['type']))
             return
 

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -601,8 +601,9 @@ class UpdateHandler(BaseHandler):
         p = handler.state[eid]['jsons'][args['win']]
 
         if not (p['type'] == 'text' or
-                p['content']['data'][0]['type'] == 'scatter'):
-            handler.write('win is not scatter or text')
+                p['content']['data'][0]['type'] in ['scatter', 'custom']):
+            handler.write('win is not scatter or text, was {}'.format(
+                p['content']['data'][0]['type']))
             return
 
         p = UpdateHandler.update(p, args)


### PR DESCRIPTION
Before we didn't allow updates through the update endpoint to custom plots, which doesn't make sense really (as they can be whatever users want). This helps temporarily alleviate #376 until we improve the marker style format.