### PR TITLE
Allows 'append' on non-existing plot for option re-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,11 @@ scatter plot. An optional `N` tensor `Y` containing discrete labels that
 range between `1` and `K` can be specified as well -- the labels will be
 reflected in the colors of the markers.
 
-`update` can be used to efficiently update the data of an existing plot. Use 'append' to append data, 'replace' to use new data, or 'remove' to remove the trace specified by `name`. If updating a single trace, use `name` to specify the name of the trace to be updated. Update data that is all NaN is ignored (can be used for masking update).
+`update` can be used to efficiently update the data of an existing plot. Use `'append'` to append data, `'replace'` to use new data, or `'remove'` to remove the trace specified by `name`.
+Using `update='createappend'` will create a plot if it doesn't exist
+and append to the existing plot otherwise.
+If updating a single trace, use `name` to specify the name of the trace to be updated. Update data that is all NaN is ignored (can be used for masking update).
+
 
 The following `opts` are supported:
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -886,6 +886,8 @@ class Visdom(object):
         delete the trace that is specified in `name`. If updating a single
         trace, use `name` to specify the name of the trace to be updated.
         Update data that is all NaN is ignored (can be used for masking update).
+        Using `update='createappend'` will create a plot if it doesn't exist
+        and append to the existing plot otherwise.
 
         The following `opts` are supported:
 
@@ -911,7 +913,13 @@ class Visdom(object):
             return self._send(data_to_send, endpoint='update')
 
         elif update is not None:
-            assert win is not None
+            assert win is not None, 'Must define a window to update'
+
+            if update == 'createappend':
+                if not self.win_exists(win, env):
+                    update = None
+                else:
+                    update = 'append'
 
             # case when X is 1 dimensional and corresponding values on y-axis
             # are passed in parameter Y
@@ -1044,6 +1052,8 @@ class Visdom(object):
         delete the trace that is specified in `name`. If updating a
         single trace, use `name` to specify the name of the trace to be updated.
         Update data that is all NaN is ignored (can be used for masking update).
+        Using `update='createappend'` will create a plot if it doesn't exist
+        and append to the existing plot otherwise.
 
         The following `opts` are supported:
 


### PR DESCRIPTION
Closes #100.

People want a blankboard so that they can use the same command in every call of an evaluation loop to plot rather than needing to instantiate the graph before they can update. Existing workarounds are doing a regular plot call on the first iteration and appends for all others, or initializing the plot with a garbage value (like 0,0 on a line) and then appending from that point. Having an option that can create or append solves the issue.

This leverages `win_exists` to determine whether a particular call should be a create or append when passed the `'createappend'` option. It then does the correct action. Tested for both line and scatter, and existing behavior is maintained.