### PR TITLE
Fix 'plotlyplot' for numpy arrays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ packages installed to use this option.
 
 This function draws a Plotly `Figure` object. It does not explicitly take options as it assumes you have already explicitly configured the figure's `layout`. 
 
+> **Note** You must have the `plotly` Python package installed to use this function. It can typically be installed by running `pip install plotly`. 
+
 #### vis.save
 This function saves the `envs` that are alive on the visdom server. It takes input a list (in python) or table (in lua) of env ids to be saved.
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -686,12 +686,19 @@ class Visdom(object):
         """
         This function draws a Plotly 'Figure' object.
         """
-        return self._send({
-            'data': figure.data,
-            'layout': figure.layout,
-            'win': win,
-            'eid': env
-        })
+        try:
+            import plotly
+            # We do a round-trip of JSON encoding and decoding to make use of the Plotly JSON Encoder.
+            # The JSON encoder deals with converting numpy arrays to Python lists and several other edge cases.
+            figure_dict = json.loads(json.dumps(figure, cls=plotly.utils.PlotlyJSONEncoder))
+            return self._send({
+                'data': figure_dict['data'],
+                'layout': figure_dict['layout'],
+                'win': win,
+                'eid': env
+            })
+        except ImportError:
+            raise RuntimeError("Plotly must be installed to plot Plotly figures")
 
     @pytorch_wrap
     def image(self, img, win=None, env=None, opts=None):

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -684,7 +684,9 @@ class Visdom(object):
 
     def plotlyplot(self, figure, win=None, env=None):
         """
-        This function draws a Plotly 'Figure' object.
+        This function draws a Plotly 'Figure' object. It does not explicitly take options as it assumes you have already explicitly configured the figure's layout.
+
+        Note: You must have the 'plotly' Python package installed to use this function. 
         """
         try:
             import plotly


### PR DESCRIPTION
I realize that the `plotlyplot` function will fail if the Plotly figure's attributes are numpy arrays instead of plain lists, since the numpy arrays cannot be serialized to JSON in `_send`. 

I thought the easiest solution is to make use of the Plotly Python client's `PlotlyJSONEncoder`, which properly deals with that as well as proper handling of NaNs and Infs. I load the JSON back as a Python dict so `_send` can add other attributes to it before JSON-serializing the entire message. 

With this, `plotly.figure_factory.create_distplot` works:

<img width="494" alt="screenshot 2018-06-25 18 05 11" src="https://user-images.githubusercontent.com/987837/41878243-5376eb68-78a2-11e8-9d7c-2398918b34b3.png">
