### PR TITLE
Don't include host in static file paths.

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -315,7 +315,7 @@ class SocketHandler(tornado.websocket.WebSocketHandler):
 
 class BaseHandler(tornado.web.RequestHandler):
     def __init__(self, *request, **kwargs):
-        self.include_host = True
+        self.include_host = False
         super(BaseHandler, self).__init__(*request, **kwargs)
 
     def get_current_user(self):


### PR DESCRIPTION
Closes https://github.com/facebookresearch/visdom/issues/411.

The line originally setting `include_host = True` was in the initial commit, so I have no idea what its purpose was. 