### PR TITLE
Hostname argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,13 @@ Visdom now can be accessed by going to `http://localhost:8097` in your browser, 
 The following options can be provided to the server:
 
 1. `-port` : The port to run the server on.
-2. `-env_path` : The path to the serialized session to reload.
-3. `-logging_level` : Logging level (default = INFO). Accepts both standard text and numeric logging values.
-4. `-readonly` : Flag to start server in readonly mode.
-5. `-enable_login` : Flag to setup authentication for the sever, requiring a username and password to login.
-6. `-force_new_cookie` : Flag to reset the secure cookie used by the server, invalidating current login cookies. Requires `-enable_login`.
+2. `-hostname` : The hostname to run the server on.
+3. `-env_path` : The path to the serialized session to reload.
+4. `-logging_level` : Logging level (default = INFO). Accepts both standard text and numeric logging values.
+5. `-readonly` : Flag to start server in readonly mode.
+6. `-enable_login` : Flag to setup authentication for the sever, requiring a username and password to login.
+7. `-force_new_cookie` : Flag to reset the secure cookie used by the server, invalidating current login cookies. 
+Requires `-enable_login`.
 
 
 #### Python example

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -37,6 +37,7 @@ import tornado.escape     # noqa E402: gotta install ioloop first
 LAYOUT_FILE = 'layouts.json'
 DEFAULT_ENV_PATH = '%s/.visdom/' % expanduser("~")
 DEFAULT_PORT = 8097
+DEFAULT_HOSTNAME = "localhost"
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -1105,8 +1106,8 @@ def download_scripts(proxies=None, install_dir=None):
             build_file.write(visdom.__version__)
 
 
-def start_server(port=DEFAULT_PORT, env_path=DEFAULT_ENV_PATH, readonly=False,
-                 print_func=None, user_credential=None):
+def start_server(port=DEFAULT_PORT, hostname=DEFAULT_HOSTNAME, env_path=DEFAULT_ENV_PATH,
+                 readonly=False, print_func=None, user_credential=None):
     print("It's Alive!")
     app = Application(port=port, env_path=env_path, readonly=readonly,
                       user_credential=user_credential)
@@ -1115,7 +1116,7 @@ def start_server(port=DEFAULT_PORT, env_path=DEFAULT_ENV_PATH, readonly=False,
     if "HOSTNAME" in os.environ:
         hostname = os.environ["HOSTNAME"]
     else:
-        hostname = "localhost"
+        hostname = hostname
     if print_func is None:
         print("You can navigate to http://%s:%s" % (hostname, port))
     else:
@@ -1127,6 +1128,8 @@ def main(print_func=None):
     parser = argparse.ArgumentParser(description='Start the visdom server.')
     parser.add_argument('-port', metavar='port', type=int, default=DEFAULT_PORT,
                         help='port to run the server on.')
+    parser.add_argument('-hostname', metavar='hostname', type=str,
+                        default=DEFAULT_HOSTNAME, help='host to run the server on.')
     parser.add_argument('-env_path', metavar='env_path', type=str,
                         default=DEFAULT_ENV_PATH,
                         help='path to serialized session to reload.')
@@ -1171,8 +1174,8 @@ def main(print_func=None):
     else:
         user_credential = None
 
-    start_server(port=FLAGS.port, env_path=FLAGS.env_path, readonly=FLAGS.readonly,
-                 print_func=print_func, user_credential=user_credential)
+    start_server(port=FLAGS.port, hostname=FLAGS.hostname, env_path=FLAGS.env_path,
+                 readonly=FLAGS.readonly, print_func=print_func, user_credential=user_credential)
 
 
 def download_scripts_and_run():


### PR DESCRIPTION
Closes #440 

The user can now pass a `-hostname` to `server.py` as an argument. Prior to this PR you could only set a HOSTNAME env variable. Adding this argument helps the user to understand they can set a custom hostname without going through the source code and spot the [env variable lines](https://github.com/facebookresearch/visdom/blob/master/py/visdom/server.py#L1115).

## How Has This Been Tested?
Tested in a conda env with python3.6 with the following commands:

- `python -m visdom.server` --> original behvoiur (serves on http://localhost:8097)
- `python -m visdom.server -hostname 0.0.0.0`
- `python -m visdom.server -hostname localhost`
- `python -m visdom.server -hostname localhost2` --> serves on localhost2 (?!)

Unfortunately I couldn't run `demo.py`. See the error trackback below. As suggested I tried `pip install -e .` or `easy_install .` but still didn't work.

```python
Exception in user code:
------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/connection.py", line 171, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/util/connection.py", line 79, in create_connection
    raise err
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/util/connection.py", line 69, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 61] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/connectionpool.py", line 354, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/http/client.py", line 1239, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/http/client.py", line 1285, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/http/client.py", line 1234, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/http/client.py", line 1026, in _send_output
    self.send(msg)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/http/client.py", line 964, in send
    self.connect()
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/connection.py", line 196, in connect
    conn = self._new_conn()
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/connection.py", line 180, in _new_conn
    self, "Failed to establish a new connection: %s" % e)
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x10f9a67b8>: Failed to establish a new connection: [Errno 61] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/requests/adapters.py", line 445, in send
    timeout=timeout
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/connectionpool.py", line 638, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/urllib3/util/retry.py", line 398, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=8097): Max retries exceeded with url: /env/main (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10f9a67b8>: Failed to establish a new connection: [Errno 61] Connection refused',))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/erotundo/git/visdom/py/visdom/__init__.py", line 446, in _send
    data=json.dumps(msg),
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/requests/api.py", line 112, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/requests/sessions.py", line 512, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/requests/sessions.py", line 622, in send
    r = adapter.send(request, **kwargs)
  File "/Users/erotundo/miniconda3/envs/visdom_dev/lib/python3.6/site-packages/requests/adapters.py", line 513, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=8097): Max retries exceeded with url: /env/main (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10f9a67b8>: Failed to establish a new connection: [Errno 61] Connection refused',))
The visdom experienced an exception while running: AssertionError('No connection could be formed quickly',)
The demo displays up-to-date functionality with the GitHub version, which may not yet be pushed to pip. Please upgrade using `pip install -e .` or `easy_install .`
If this does not resolve the problem, please open an issue on our GitHub.
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
