### PR TITLE
Python method for retrieving the list of environment names from the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Start the server (probably in a  `screen` or `tmux`) from the command line:
 
 Visdom now can be accessed by going to `http://localhost:8097` in your browser, or your own host address if specified.
 
-> The `visdom` command is equivalent to running `python -m visdom.server`. 
+> The `visdom` command is equivalent to running `python -m visdom.server`.
 
 >If the above does not work, try using an SSH tunnel to your server by adding the following line to your local  `~/.ssh/config`:
 ```LocalForward 127.0.0.1:8097 127.0.0.1:8097```.
@@ -189,7 +189,7 @@ The following options can be provided to the server:
 4. `-logging_level` : Logging level (default = INFO). Accepts both standard text and numeric logging values.
 5. `-readonly` : Flag to start server in readonly mode.
 6. `-enable_login` : Flag to setup authentication for the sever, requiring a username and password to login.
-7. `-force_new_cookie` : Flag to reset the secure cookie used by the server, invalidating current login cookies. 
+7. `-force_new_cookie` : Flag to reset the secure cookie used by the server, invalidating current login cookies.
 Requires `-enable_login`.
 
 
@@ -291,6 +291,7 @@ vis._send({'data': [trace], 'layout': layout, 'win': 'mywin'})
 - [`vis.close`](#visclose)    : close a window by id
 - [`vis.delete_env`](#visdelete_env) : delete an environment by env_id
 - [`vis.win_exists`](#viswin_exists) : check if a window already exists by id
+- [`vis.get_env_list`](#visget_env_list) : get a list of all of the environments on your server
 - [`vis.win_hash`](#viswin_hash): get md5 hash of window's contents
 - [`vis.get_window_data`](#visget_window_data): get current data for a window
 - [`vis.check_connection`](#vischeck_connection): check if the server is connected
@@ -397,9 +398,9 @@ packages installed to use this option.
 
 #### vis.plotlyplot
 
-This function draws a Plotly `Figure` object. It does not explicitly take options as it assumes you have already explicitly configured the figure's `layout`. 
+This function draws a Plotly `Figure` object. It does not explicitly take options as it assumes you have already explicitly configured the figure's `layout`.
 
-> **Note** You must have the `plotly` Python package installed to use this function. It can typically be installed by running `pip install plotly`. 
+> **Note** You must have the `plotly` Python package installed to use this function. It can typically be installed by running `pip install plotly`.
 
 #### vis.save
 This function saves the `envs` that are alive on the visdom server. It takes input a list (in python) or table (in lua) of env ids to be saved.
@@ -622,6 +623,10 @@ This function returns a bool indicating whether or not a window `win` exists on 
 
 Optional arguments:
 - `env`: Environment to search for the window in. Default is `None`.
+
+#### vis.get_env_list
+
+This function returns a list of all of the environments on the server at the time of calling. It takes no arguments.
 
 #### vis.win_hash
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -536,6 +536,13 @@ class Visdom(object):
             'eid': env,
         }, endpoint='win_exists', quiet=True)
 
+    def get_env_list(self):
+        """
+        This function returns a list of all of the env names that are currently
+        in the server.
+        """
+        return json.loads(self._send({}, endpoint='env_state', quiet=True))
+
     def win_exists(self, win, env=None):
         """
         This function returns a bool indicating whether

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -157,6 +157,7 @@ class Application(tornado.web.Application):
             (r"/win_data", DataHandler, {'app': self}),
             (r"/delete_env", DeleteEnvHandler, {'app': self}),
             (r"/win_hash", HashHandler, {'app': self}),
+            (r"/env_state", EnvStateHandler, {'app': self}),
             (r"/(.*)", IndexHandler, {'app': self}),
         ]
         super(Application, self).__init__(handlers, **tornado_settings)
@@ -670,6 +671,25 @@ class DeleteEnvHandler(BaseHandler):
             tornado.escape.to_basestring(self.request.body)
         )
         self.wrap_func(self, args)
+
+
+class EnvStateHandler(BaseHandler):
+    def initialize(self, app):
+        self.app = app
+        self.state = app.state
+
+    @staticmethod
+    def wrap_func(handler, args):
+        # TODO if an env is provided return the state of that env
+        all_eids = list(handler.state.keys())
+        handler.write(json.dumps(all_eids))
+
+    def post(self):
+        args = tornado.escape.json_decode(
+            tornado.escape.to_basestring(self.request.body)
+        )
+        self.wrap_func(self, args)
+
 
 class HashHandler(BaseHandler):
     def initialize(self, app):


### PR DESCRIPTION
## Description
Introduces a way to get a list of all of the environment names from the server. Could be useful to make some python tooling around sorting and deleting environments, and also later around downloading and saving environments.

## Motivation and Context
Implements https://github.com/facebookresearch/visdom/issues/445

## How Has This Been Tested?
Tested by running in terminal

## Screenshots (if appropriate):
<img width="493" alt="screen shot 2018-08-29 at 11 19 51 pm" src="https://user-images.githubusercontent.com/1276867/44827666-12baf100-abe2-11e8-9151-56bce8a49f84.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
