### PR TITLE
Fixing vanishing legends (and other plot opts)

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1144,11 +1144,13 @@ class Visdom(object):
                 if marker_prop in opts:
                     del opts[marker_prop]
 
+        # Only send updates to the layout on the first plot, future updates
+        # need to use `update_window_opts`
         data_to_send = {
             'data': data,
             'win': win,
             'eid': env,
-            'layout': _opts2layout(opts, is3d),
+            'layout': _opts2layout(opts, is3d) if update is None else {},
             'opts': opts,
         }
         endpoint = 'events'

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -357,11 +357,13 @@ class BaseHandler(tornado.web.RequestHandler):
 def update_window(p, args):
     """Adds new args to a window if they exist"""
     content = p['content']
-    layout = content['layout']
-    layout.update(args.get('layout', {}))
+    layout_update = args.get('layout', {})
+    for layout_name, layout_val in layout_update.items():
+        if layout_val is not None:
+            content['layout'][layout_name] = layout_val
     opts = args.get('opts', {})
     for opt_name, opt_val in opts.items():
-        if opt_name in p:
+        if opt_val is not None:
             p[opt_name] = opt_val
 
     if 'legend' in opts:


### PR DESCRIPTION
## Description
The implementation of updating plot options had the unintended effect of dropping the legend after the first plot update, as scatter would send an updated set of layout options on every update. Now it doesn't send such a list on update plots, which will now require "update_window_opts" to update the layout after a plot has been created.

## Motivation and Context
Fixes https://github.com/facebookresearch/visdom/issues/406
Properly fixes https://github.com/facebookresearch/visdom/issues/434

## How Has This Been Tested?
Run the demo, ensure some plots that were missing legends after an append now retain their legends when an append occurs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
