### PR TITLE
python server/client: use secure cookies everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ The python visdom client takes a few options:
 - `use_incoming_socket`: enable use of the socket for receiving events from the web client, allowing user to register callbacks (default: `True`)
 - `http_proxy_host`: host to proxy your incoming socket through (default: `None`)
 - `http_proxy_port`: port to proxy your incoming socket through (default: `None`)
+- `username`: username to use for authentication, if server started with `-enable_login` (default: `None`)
+- `password`: password to use for authentication, if server started with `-enable_login` (default: `None`)
 
 Other options are either currently unused (endpoint, ipv6) or used for internal functionality (send allows the visdom server to replicate events for the lua client).
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -39,22 +39,6 @@ try:
 except ImportError:
     BS4_AVAILABLE = False
 
-import http.client as http_client
-
-http_client.HTTPConnection.debuglevel = 1
-
-logging.basicConfig()
-logging.getLogger().setLevel(logging.DEBUG)
-requests_log = logging.getLogger("requests.packages.urllib3")
-requests_log.setLevel(logging.DEBUG)
-requests_log.propagate = True
-
-logger = logging.getLogger('websocket')
-logger.setLevel(logging.DEBUG)
-
-
-THREAD_LOCAL = type('storage', (object,), {})  # threading.local()
-
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -483,7 +467,6 @@ class Visdom(object):
                 try:
                     sock_addr = "{}://{}:{}{}/vis_socket".format(
                         ws_scheme, self.server_base_name, self.port, self.base_url)
-                    cookie = "'foobar': 'baz', user_password': '%s'" % self.session.cookies.get('user_password', '')
                     ws = websocket.WebSocketApp(
                         sock_addr,
                         on_message=on_message,


### PR DESCRIPTION
python client: passes the secure cookie through the web socket
python server: check the secure cookie in all get/post requests

## Motivation and Context

authentication for the web interface was implemented in #330. However, this didn't prevent anyone from using POST requests. Also, the web socket wasn't secured.

## How Has This Been Tested?

* try posting with correct/incorrect credentials
* everything still works when starting the server without `-enable_login`


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
