### PR TITLE
Fix download script to work in containers.

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -7,7 +7,8 @@ wget https://unpkg.com/react@16.2.0/umd/react.production.min.js -O py/static/js/
 wget https://unpkg.com/react-dom@16.2.0/umd/react-dom.production.min.js -O py/static/js/react-dom.min.js
 wget "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG" -O py/static/js/mathjax-MathJax.js
 wget https://cdn.rawgit.com/plotly/plotly.js/master/dist/plotly.min.js -O py/static/js/plotly-plotly.min.js
-wget https://unpkg.com/sjcl@1.0.7/sjcl.js -O py/static/js/scjl.js
+wget https://unpkg.com/sjcl@1.0.7/sjcl.js -O py/static/js/sjcl.js
+wget https://cdnjs.cloudflare.com/ajax/libs/react-modal/3.6.1/react-modal.min.js -o py/static/js/react-modal.min.js
 
 
 mkdir -p py/static/css


### PR DESCRIPTION
## Description
Fix the download script to prepare the environment correctly for containers.

## Motivation and Context
When running in a container, the `download.sh` script requires running at build-time, since the resulting container is read-only. This PR fixes a typo in the `sjcl.js` download, and adds `react-modal.min.js` which is required for `python -m visdom.server` to run.
Running visdom server fails with errors such as `IOError: [Errno 13] Permission denied: u'/opt/rl-setup/visdom/py/visdom/static/js/react-modal.min.js` because the download script has has previously downloaded .
Similarly `IOError: [Errno 13] Permission denied: u'/opt/rl-setup/visdom/py/visdom/static/js/sjcl.js` occurs due to a typo in the script.

## How Has This Been Tested?
Fixed the download script on a fork and created a singularity container to install the visdom package from github.
python -m visdom.server; python demo.py now works.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
