### PR TITLE
Fix plotly ylabel

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -185,7 +185,7 @@ def _opts2layout(opts, is3d=False):
         }
     else:
         layout['xaxis'] = _axisformat('x', opts)
-        layout['yaxis'] = _axisformat('x', opts)
+        layout['yaxis'] = _axisformat('y', opts)
 
     if opts.get('stacked'):
         layout['barmode'] = 'stack' if opts.get('stacked') else 'group'


### PR DESCRIPTION
Fix the ylabel of plotly windows

## Description
Due to a typo, the label of the yaxis in a plotly graph would use the label of the yaxis. This PR fixes this typo.

## How Has This Been Tested?
Manually by running an example. The bug can be reproduced by the following code:
```
from visdom import Visdom
import numpy as np

X = np.linspace(0, 4, 200)

viz = Visdom()
viz.line(
    env="demo_ylabel_bug",
    X=X,
    Y=np.sin(X),
    opts=dict(
        xlabel='x-axis',
        ylabel='y-axis',
        title='ylabel bug',
    ),
)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
