### PR TITLE
Updating flag for hostname, was clashing with -h

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1168,7 +1168,7 @@ def main(print_func=None):
     parser.add_argument('-port', metavar='port', type=int,
                         default=DEFAULT_PORT,
                         help='port to run the server on.')
-    parser.add_argument('-hostname', metavar='hostname', type=str,
+    parser.add_argument('--hostname', metavar='hostname', type=str,
                         default=DEFAULT_HOSTNAME,
                         help='host to run the server on.')
     parser.add_argument('-base_url', metavar='base_url', type=str,


### PR DESCRIPTION
Changed the flag for hostname from -hostname to  --hostname. Currently, when you type -hostname, it is interpreted as -h for help. So, currently it's not possible to host visdom on a server other than localhost.

This PR would prevent the clash with argparse's flag for help -h.

Example use:-

To run visdom server on a public server https://yourpublicserver at port 9000 you can now run the following command:

```
python server.py --hostname https://yourpublicserver -port 9000
```

Hope this helps others like me who want to host on a server other than localhost!

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
