### PR TITLE
Allow scatter plots with more legend items than number of classes

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1137,7 +1137,7 @@ class Visdom(object):
         _assert_opts(opts)
 
         if opts.get('legend'):
-            assert type(opts['legend']) == list and len(opts['legend']) >= K, \
+            assert type(opts['legend']) == list and K <= len(opts['legend']), \
                 'largest label should not be greater than size of the ' \
                 'legends table'
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1110,7 +1110,7 @@ class Visdom(object):
             Y = np.ones(X.shape[0], dtype=int)
 
         assert np.equal(np.mod(Y, 1), 0).all(), 'labels should be integers'
-        assert Y.min() == 1, 'labels are assumed to be between 1 and K'
+        assert Y.min() >= 1, 'labels are assumed to be between 1 and K'
 
         K = int(Y.max())
         is3d = X.shape[1] == 3
@@ -1137,7 +1137,9 @@ class Visdom(object):
         _assert_opts(opts)
 
         if opts.get('legend'):
-            assert type(opts['legend']) == list and len(opts['legend']) == K
+            assert type(opts['legend']) == list and len(opts['legend']) >= K, \
+                'largest label should not be greater than size of the ' \
+                'legends table'
 
         data = []
         trace_opts = opts.get('traceopts', {'plotly': {}})['plotly']


### PR DESCRIPTION
## Description
Change two assert statements in the scatter function from == to >=. This is done in order to -
- allow more legend items than number of classes
- allow the label 1 to be missing and assert that the minimum label is not less than 1

## Motivation and Context
Closes #480 
Also allows scatter function calls with label 1 missing. This could happen in a case in which the label 1 is not included in the scatter function call

## How Has This Been Tested?
This has been tested by making 3d scatter plots by modifying demo.py. The 3d scatter demo in demo.py contains 2 legend items. I have increased it to 3 legend items and then made 3 plots -
- with the same labels as demo.py, ie, [1, 2]
- with labels [2, 3]
- with labels [1, 2]
Screenshot is attached below for all 3 plots.

In addition to this, I have tested the demo.py file on both my branch and a clean branch and everything is the same.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10346824/47455069-ea451280-d79e-11e8-8a76-505a53ae938b.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
