### PR TITLE
Fix squeeze issue on single-element arrays

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1133,8 +1133,7 @@ class Visdom(object):
         assert X.shape[1] == 2 or X.shape[1] == 3, 'X should have 2 or 3 cols'
 
         if Y is not None:
-            Y = np.squeeze(Y)
-            assert Y.ndim == 1, 'Y should be one-dimensional'
+            Y = np.ravel(Y)
             assert X.shape[0] == Y.shape[0], 'sizes of X and Y should match'
         else:
             Y = np.ones(X.shape[0], dtype=int)
@@ -1159,7 +1158,7 @@ class Visdom(object):
 
         L = opts.get('textlabels')
         if L is not None:
-            L = np.squeeze(L)
+            L = np.ravel(L)
             assert len(L) == X.shape[0], \
                 'textlabels and X should have same shape'
 


### PR DESCRIPTION
Replace `np.squeeze` by `np.ravel` to get a 1D array.

## Description
This avoid getting 0-dimensional arrays when the input has only one element. 

## Motivation and Context
Fixes https://github.com/facebookresearch/visdom/issues/301 and https://github.com/facebookresearch/visdom/issues/444

## How Has This Been Tested?
Running snippets like this one was raising the following error: `AssertionError: Y should be one-dimensional`
```
from visdom import Visdom

viz = Visdom()
viz.scatter(X=[[0,1]], Y=[1])
```
Which runs smoothly now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
