### PR TITLE
Handle silently (warn) when trying to load corrupt env json.

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -146,8 +146,13 @@ class Application(tornado.web.Application):
 
         for env_json in env_jsons:
             env_path_file = os.path.join(env_path, env_json)
-            env_data = \
-                tornado.escape.json_decode(open(env_path_file, 'r').read())
+            try:
+                env_data = \
+                    tornado.escape.json_decode(open(env_path_file, 'r').read())
+            except:
+                logging.warn("Failed loading environment json: {}".format(env_path_file))
+                continue
+
             eid = env_json.replace('.json', '')
             self.state[eid] = {'jsons': env_data['jsons'],
                                'reload': env_data['reload']}


### PR DESCRIPTION
Fix issue #507. 

## Description
Throw a warning when (instead of crashing) when failing to load an environment json.

## Motivation and Context
Currently the visdom server fails to start when trying to load a corrupt json environment file. The thrown exception does not indicate the name of the corrupt file. This fix will log a warning stating the corrupt json file and continue with starting the server.

## How Has This Been Tested?
Tested on several corrupted json files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
