### PR TITLE
Line different dash types

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ The following `opts` are supported:
 - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
 - `opts.markersize`  : marker size (`number`; default = `'10'`)
 - `opts.linecolor`   : line colors (`np.array`; default = None)
-- `opts.dash`        : line dash type for each line (`np.array`; default = None), one of `solid`, `dash`, `dashdot` or `dash`, size should match number of lines being drawn
+- `opts.dash`        : line dash type for each line (`np.array`; default = 'solid'), one of `solid`, `dash`, `dashdot` or `dash`, size should match number of lines being drawn
 - `opts.legend`      : `table` containing legend names
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`   : `dict` mapping trace names or indices to `dict`s of additional options that plot.ly accepts for a trace.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ The following `opts` are supported:
 - `opts.markers`     : show markers (`boolean`; default = `false`)
 - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
 - `opts.markersize`  : marker size (`number`; default = `'10'`)
+- `opts.linecolor`   : line colors (`np.array`; default = None)
 - `opts.dash`        : line dash type for each line (`np.array`; default = None), one of `solid`, `dash`, `dashdot` or `dash`, size should match number of lines being drawn
 - `opts.legend`      : `table` containing legend names
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ The following `opts` are supported:
 - `opts.markers`     : show markers (`boolean`; default = `false`)
 - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
 - `opts.markersize`  : marker size (`number`; default = `'10'`)
+- `opts.dash`        : line dash type for each line (`np.array`; default = None), one of `solid`, `dash`, `dashdot` or `dash`, size should match number of lines being drawn
 - `opts.legend`      : `table` containing legend names
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`   : `dict` mapping trace names or indices to `dict`s of additional options that plot.ly accepts for a trace.

--- a/example/demo.py
+++ b/example/demo.py
@@ -317,6 +317,34 @@ try:
         opts=dict(title='{} points using WebGL'.format(webgl_num_points*2), webgl=True)
     )
 
+    win = viz.line(
+        X=np.column_stack((
+            np.arange(0, 10),
+            np.arange(0, 10),
+            np.arange(0, 10),
+        )),
+        Y=np.column_stack((
+            np.linspace(5, 10, 10),
+            np.linspace(5, 10, 10) + 5,
+            np.linspace(5, 10, 10) + 10,
+        )),
+        opts={
+            'dash': np.array(['solid', 'dash', 'dashdot']),
+            'title': 'Different line dash types'
+        }
+    )
+
+    viz.line(
+        X=np.arange(0, 10),
+        Y=np.linspace(5, 10, 10) + 15,
+        win=win,
+        name='4',
+        update='insert',
+        opts={
+            'dash': np.array(['dot']),
+        }
+    )
+
     Y = np.linspace(0, 4, 200)
     win = viz.line(
         Y=np.column_stack((np.sqrt(Y), np.sqrt(Y) + 2)),

--- a/example/demo.py
+++ b/example/demo.py
@@ -330,6 +330,11 @@ try:
         )),
         opts={
             'dash': np.array(['solid', 'dash', 'dashdot']),
+            'linecolor': np.array([
+                [0, 191, 255],
+                [0, 191, 255],
+                [255, 0, 0],
+            ]),
             'title': 'Different line dash types'
         }
     )
@@ -341,6 +346,9 @@ try:
         name='4',
         update='insert',
         opts={
+            'linecolor': np.array([
+                [255, 0, 0],
+            ]),
             'dash': np.array(['dot']),
         }
     )

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1106,7 +1106,7 @@ class Visdom(object):
         - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
         - `opts.markersize`  : marker size (`number`; default = `'10'`)
         - `opts.markercolor` : marker color (`np.array`; default = `None`)
-        - `opts.dash`        : dash type (`np.array`; default = None`)
+        - `opts.dash`        : dash type (`np.array`; default = 'solid'`)
         - `opts.textlabels`  : text label for each point (`list`: default = `None`)
         - `opts.legend`      : `table` containing legend names
         """

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1202,8 +1202,6 @@ class Visdom(object):
         dash = opts.get('dash')
         mc = opts.get('markercolor')
         lc = opts.get('linecolor')
-        print(opts.get('title', None))
-        print(lc)
 
         for k in range(1, K + 1):
             ind = np.equal(Y, k)

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -230,6 +230,17 @@ def _markerColorCheck(mc, X, Y, L):
     return ret
 
 
+def _lineColorCheck(lc, K):
+    assert isndarray(lc), 'lc should be a numpy ndarray'
+    assert lc.shape[0] == K, 'lc should be same shape as K'
+
+    assert (lc >= 0).all(), 'line colors have to be >= 0'
+    assert (lc <= 255).all(), 'line colors have to be <= 255'
+    assert (lc == np.floor(lc)).all(), 'line colors are assumed to be ints'
+
+    return ['#%02x%02x%02x' % (i[0], i[1], i[2]) for i in lc]
+
+
 def _dashCheck(dash, K):
     assert isndarray(dash), 'dash should be a numpy ndarray'
     assert dash.shape[0] == K, 'dash should be same shape as K'
@@ -1164,6 +1175,10 @@ class Visdom(object):
             opts['markercolor'] = _markerColorCheck(
                 opts['markercolor'], X, Y, K)
 
+        if opts.get('linecolor') is not None:
+            opts['linecolor'] = _lineColorCheck(
+                opts['linecolor'], K)
+
         if opts.get('dash') is not None:
             opts['dash'] = _dashCheck(
                 opts['dash'], K)
@@ -1186,6 +1201,9 @@ class Visdom(object):
         trace_opts = opts.get('traceopts', {'plotly': {}})['plotly']
         dash = opts.get('dash')
         mc = opts.get('markercolor')
+        lc = opts.get('linecolor')
+        print(opts.get('title', None))
+        print(lc)
 
         for k in range(1, K + 1):
             ind = np.equal(Y, k)
@@ -1208,6 +1226,7 @@ class Visdom(object):
                     'textposition': 'right',
                     'line': {
                         'dash': dash[k-1] if dash is not None else None,
+                        'color': lc[k-1] if lc is not None else None,
                     },
                     'marker': {
                         'size': opts.get('markersize'),
@@ -1234,6 +1253,9 @@ class Visdom(object):
             for marker_prop in ['markercolor']:
                 if marker_prop in opts:
                     del opts[marker_prop]
+            for line_prop in ['linecolor']:
+                if line_prop in opts:
+                    del opts[line_prop]
             for dash in ['dash']:
                 if dash in opts:
                     del opts[dash]
@@ -1279,6 +1301,7 @@ class Visdom(object):
         - `opts.markers`     : show markers (`boolean`; default = `false`)
         - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
         - `opts.markersize`  : marker size (`number`; default = `'10'`)
+        - `opts.linecolor`   : line colors (`np.array`; default = None)
         - `opts.dash`        : line dash type (`np.array`; default = None)
         - `opts.legend`      : `table` containing legend names
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -230,6 +230,13 @@ def _markerColorCheck(mc, X, Y, L):
     return ret
 
 
+def _dashCheck(dash, K):
+    assert isndarray(dash), 'dash should be a numpy ndarray'
+    assert dash.shape[0] == K, 'dash should be same shape as K'
+
+    return dash
+
+
 def _assert_opts(opts):
     if opts.get('color'):
         assert isstr(opts.get('color')), 'color should be a string'
@@ -1088,6 +1095,7 @@ class Visdom(object):
         - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
         - `opts.markersize`  : marker size (`number`; default = `'10'`)
         - `opts.markercolor` : marker color (`np.array`; default = `None`)
+        - `opts.dash`        : dash type (`np.array`; default = None`)
         - `opts.textlabels`  : text label for each point (`list`: default = `None`)
         - `opts.legend`      : `table` containing legend names
         """
@@ -1156,6 +1164,10 @@ class Visdom(object):
             opts['markercolor'] = _markerColorCheck(
                 opts['markercolor'], X, Y, K)
 
+        if opts.get('dash') is not None:
+            opts['dash'] = _dashCheck(
+                opts['dash'], K)
+
         L = opts.get('textlabels')
         if L is not None:
             L = np.ravel(L)
@@ -1172,10 +1184,12 @@ class Visdom(object):
 
         data = []
         trace_opts = opts.get('traceopts', {'plotly': {}})['plotly']
+        dash = opts.get('dash')
+        mc = opts.get('markercolor')
+
         for k in range(1, K + 1):
             ind = np.equal(Y, k)
             if ind.any():
-                mc = opts.get('markercolor')
                 if 'legend' in opts:
                     trace_name = opts.get('legend')[k - 1]
                 elif K == 1 and name is not None:
@@ -1192,13 +1206,16 @@ class Visdom(object):
                     'mode': opts.get('mode'),
                     'text': L[ind].tolist() if L is not None else None,
                     'textposition': 'right',
+                    'line': {
+                        'dash': dash[k-1] if dash is not None else None,
+                    },
                     'marker': {
                         'size': opts.get('markersize'),
                         'symbol': opts.get('markersymbol'),
                         'color': mc[k] if mc is not None else None,
                         'line': {
                             'color': '#000000',
-                            'width': 0.5
+                            'width': 0.5,
                         }
                     }
                 }
@@ -1217,6 +1234,9 @@ class Visdom(object):
             for marker_prop in ['markercolor']:
                 if marker_prop in opts:
                     del opts[marker_prop]
+            for dash in ['dash']:
+                if dash in opts:
+                    del opts[dash]
 
         # Only send updates to the layout on the first plot, future updates
         # need to use `update_window_opts`
@@ -1259,6 +1279,7 @@ class Visdom(object):
         - `opts.markers`     : show markers (`boolean`; default = `false`)
         - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
         - `opts.markersize`  : marker size (`number`; default = `'10'`)
+        - `opts.dash`        : line dash type (`np.array`; default = None)
         - `opts.legend`      : `table` containing legend names
 
         If `update` is specified, the figure will be updated without


### PR DESCRIPTION
## Description
Provides a way to specify colors and dash type when plotting lines.

`vis.line()` now takes in additional opts fields `linecolor` and `dash`. Each field is an ndarray with the same number of items as there are lines being drawn. Each item can be used to specify the color and dash type for the lines in the given order.

## Motivation and Context
Fulfills feature request #376 

## How Has This Been Tested?
Added example in `example/demo.py` and ran the demo.

```
    win = viz.line(
        X=np.column_stack((
            np.arange(0, 10),
            np.arange(0, 10),
            np.arange(0, 10),
        )),
        Y=np.column_stack((
            np.linspace(5, 10, 10),
            np.linspace(5, 10, 10) + 5,
            np.linspace(5, 10, 10) + 10,
        )),
        opts={
            'dash': np.array(['solid', 'dash', 'dashdot']),
            'linecolor': np.array([
                [0, 191, 255],
                [0, 191, 255],
                [255, 0, 0],
            ]),
            'title': 'Different line dash types'
        }
    )

    viz.line(
        X=np.arange(0, 10),
        Y=np.linspace(5, 10, 10) + 15,
        win=win,
        name='4',
        update='insert',
        opts={
            'linecolor': np.array([
                [255, 0, 0],
            ]),
            'dash': np.array(['dot']),
        }
    )
```

## Screenshots (if appropriate):
<img width="391" alt="screen shot 2018-12-13 at 5 04 29 pm" src="https://user-images.githubusercontent.com/5044777/49970417-30923480-fef9-11e8-8453-ca9e190b3c36.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.