### PR TITLE
set explicit link to layout_bin_packer (avoid wrong redirects)

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -19,7 +19,7 @@ wget https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css -O py/static/c
 
 mkdir -p py/static/fonts
 wget https://unpkg.com/classnames@2.2.5 -O py/static/fonts/classnames
-wget https://unpkg.com/layout-bin-packer@1.4.0 -O py/static/fonts/layout_bin_packer
+wget https://unpkg.com/layout-bin-packer@1.4.0/dist/layout-bin-packer.js -O py/static/fonts/layout_bin_packer
 wget https://unpkg.com/bootstrap@3.3.7/dist/fonts/glyphicons-halflings-regular.eot -O py/static/fonts/glyphicons-halflings-regular.eot
 wget https://unpkg.com/bootstrap@3.3.7/dist/fonts/glyphicons-halflings-regular.woff2 -O py/static/fonts/glyphicons-halflings-regular.woff2
 wget https://unpkg.com/bootstrap@3.3.7/dist/fonts/glyphicons-halflings-regular.woff -O py/static/fonts/glyphicons-halflings-regular.woff

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1133,7 +1133,7 @@ def download_scripts(proxies=None, install_dir=None):
 
         # - fonts
         '%sclassnames@2.2.5' % b: 'classnames',
-        '%slayout-bin-packer@1.4.0' % b: 'layout_bin_packer',
+        '%slayout-bin-packer@1.4.0/dist/layout-bin-packer.js' % b: 'layout_bin_packer',
         '%sfonts/glyphicons-halflings-regular.eot' % bb:
             'glyphicons-halflings-regular.eot',
         '%sfonts/glyphicons-halflings-regular.woff2' % bb:
@@ -1180,11 +1180,12 @@ def download_scripts(proxies=None, install_dir=None):
     for (key, val) in ext_files.items():
 
         # set subdirectory:
-        sub_dir = 'fonts'
-        if '.js' in key:
+        if val.endswith('.js'):
             sub_dir = 'js'
-        if '.css' in key:
+        elif val.endswith('.css'):
             sub_dir = 'css'
+        else:
+            sub_dir = 'fonts'
 
         # download file:
         filename = '%s/static/%s/%s' % (install_dir, sub_dir, val)


### PR DESCRIPTION
This commit fixes https://github.com/facebookresearch/visdom/issues/529. For some reason, `https://unpkg.com/layout-bin-packer@1.4.0` might redirect to `https://unpkg.com/layout-bin-packer@1.4.0/index.js` instead of the correct `https://unpkg.com/layout-bin-packer@1.4.0/dist/layout-bin-packer.js`.

## How Has This Been Tested?
Tested by building from scripts in a new env.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This commit might bring a breaking change if `https://unpkg.com` developers, for some reason, decide to change the default redirect of `https://unpkg.com/layout-bin-packer@1.4.0` to some other URL. The risk is negligible, and this commit can be easily reverted.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
