### PR TITLE
Added proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,11 @@ The python visdom client takes a few options:
 - `raise_exceptions`: Raise exceptions upon failure rather than printing them (default: `True` (soon))
 - `log_to_filename`: If not none, log all plotting and updating events to the given file (append mode) so that they can be replayed later using `replay_log` (default: `None`)
 - `use_incoming_socket`: enable use of the socket for receiving events from the web client, allowing user to register callbacks (default: `True`)
-- `http_proxy_host`: host to proxy your incoming socket through (default: `None`)
-- `http_proxy_port`: port to proxy your incoming socket through (default: `None`)
+- `http_proxy_host`: Deprecated. Use Proxies argument for complete proxy support.
+- `http_proxy_port`: Deprecated. Use Proxies argument for complete proxy support.
 - `username`: username to use for authentication, if server started with `-enable_login` (default: `None`)
 - `password`: password to use for authentication, if server started with `-enable_login` (default: `None`)
+- `proxies`: Dictionary mapping protocol to the URL of the proxy (e.g. {‘http’: ‘foo.bar:3128’}) to be used on each Request. (default: `None`)
 
 Other options are either currently unused (endpoint, ipv6) or used for internal functionality (send allows the visdom server to replicate events for the lua client).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates Visdom library to add Proxy support.

## Description
<!--- Describe your changes in detail -->
Deprecated http_proxy_host and http_proxy_host in favor of generic proxies argument which updates socket and session to use proxy dict passed by user.
http_proxy_host and port are inferred from the proxy dict if proxy for http protocol is provided. Right now supports only IPv4 proxy arguments.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#528 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->


```
import visdom
import numpy as np
vis = visdom.Visdom(server='http://226f5da3.ngrok.io/', port=80, proxies={'http': '31.41.68.79:49480'})
# vis = visdom.Visdom(server='http://226f5da3.ngrok.io/', port=80)
# vis = visdom.Visdom()
vis.text('Hello via Proxy!')
vis.image(np.ones((3, 10, 10)))
```

Updates visdom canvas by routing request through proxy provided.

## Screenshots (if appropriate):
![screen shot 2019-01-08 at 1 27 20 pm](https://user-images.githubusercontent.com/5303204/50851047-a8614c80-1349-11e9-8d63-abc0784f623d.png)
