### PR TITLE
Remove non-ASCII characters in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ The python visdom client takes a few options:
 - `http_proxy_port`: Deprecated. Use Proxies argument for complete proxy support.
 - `username`: username to use for authentication, if server started with `-enable_login` (default: `None`)
 - `password`: password to use for authentication, if server started with `-enable_login` (default: `None`)
-- `proxies`: Dictionary mapping protocol to the URL of the proxy (e.g. {‘http’: ‘foo.bar:3128’}) to be used on each Request. (default: `None`)
+- `proxies`: Dictionary mapping protocol to the URL of the proxy (e.g. {`http`: `foo.bar:3128`}) to be used on each Request. (default: `None`)
 
 Other options are either currently unused (endpoint, ipv6) or used for internal functionality (send allows the visdom server to replicate events for the lua client).
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'py/visdom/VERSION')) as version_file:
     version = version_file.read().strip()
 
-readme = open('README.md').read()
+readme = open('README.md', 'rt', encoding='utf8').read()
 
 requirements = [
     'numpy>=1.8',


### PR DESCRIPTION
## Description

Simply replace characters ‘ by \' in `README.md` and encode the `README.md` file in `setup.py` to avoid further problems if non-ASCII characters were to be added again.

## Motivation and Context

Reading a file with non-ascii characters will raise a UnicodeDecodeError if the system locale is not set to UTF-8. Note that the characters in question are not coherent with the rest of the documentation and should be ` rather than ‘.

## How Has This Been Tested?

Tested in a container where locale is not UTF-8. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.