### PR TITLE
Fixes incompatbility with Python 2.7 - issue #548

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+from io import open
 from setuptools import setup
 from pkg_resources import get_distribution, DistributionNotFound
 


### PR DESCRIPTION
Fixes #548 

## Description
Use `io.open` to be compatible with Python 2 and Python 3. 

## How Has This Been Tested?
```
python --version
> Python 2.7.15 :: Anaconda, Inc.
python setup.py build
```
and 
```
python --version
> Python 3.6.8 :: Anaconda, Inc.
python setup.py build
```