### PR TITLE
Check title subproperty for plotly graphs, supporting both newer & deprecated API

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -870,7 +870,13 @@ class Visdom(object):
             # We add the paramater to opts manually if it exists.
             opts = dict()
             if 'title' in figure_dict['layout']:
-                opts['title'] = figure_dict['layout']['title']
+                title_prop = figure_dict['layout']['title']
+
+                # The title is now officially under a 'text' subproperty. Previously, the property
+                # itself could also directly reference the title.
+                # Although this latter behavior is now deprecated, we support both possibilities.
+                # Docs reference: https://plot.ly/python/reference/#layout-title-text
+                opts['title'] = title_prop['text'] if 'text' in title_prop else title_prop
 
             return self._send({
                 'data': figure_dict['data'],


### PR DESCRIPTION
## Description

The newer plotly API supports having the title as a subproperty called `text`. This fix checks if that exists first and uses it, otherwise, it reverts back to the older/current behavior (which is now deprecated by plotly).

## Motivation and Context

Fixes #557 

## How Has This Been Tested?

1) This new test case now passes (title as a subproperty):
```python
from visdom import Visdom
from plotly import tools
import plotly.graph_objs as go
import plotly.offline as py

fig = tools.make_subplots(rows=2, cols=1, subplot_titles=('first', 'second'), print_grid=False)
fig.append_trace(go.Scatter(x=[1, 2, 3], y=[1, 2, 3], name='s1'), 1, 1)
fig.append_trace(go.Scatter(x=[1, 2, 3], y=[1, 2, 3], name='s2'), 2, 1)
fig['layout'].update(title='whatever')
vis = Visdom()
```

2) This regression test case continues to work with the older deprecated API (title as a direct property):
```python
import visdom
vis = visdom.Visdom()

trace = dict(x=[1, 2, 3], y=[4, 5, 6], mode="markers+lines", type='custom',
             marker={'color': 'red', 'symbol': 104, 'size': "10"},
             text=["one", "two", "three"], name='1st Trace')
layout = dict(title="First Plot", xaxis={'title': 'x1'}, yaxis={'title': 'x2'})

vis._send({'data': [trace], 'layout': layout, 'win': 'mywin'})
```

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
