### PR TITLE
Fixing plotting multiple single points.

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1342,10 +1342,6 @@ class Visdom(object):
         else:
             X = np.linspace(0, 1, Y.shape[0])
 
-        if Y.ndim == 2 and Y.shape[1] == 1:
-                Y = Y.reshape(Y.shape[0])
-                X = X.reshape(X.shape[0])
-
         if Y.ndim == 2 and X.ndim == 1:
             X = np.tile(X, (Y.shape[1], 1)).transpose()
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1342,6 +1342,10 @@ class Visdom(object):
         else:
             X = np.linspace(0, 1, Y.shape[0])
 
+        if Y.ndim == 2 and Y.shape[1] == 1:
+                Y = Y.reshape(1, Y.shape[0])
+                X = X.reshape(X.shape[0])
+
         if Y.ndim == 2 and X.ndim == 1:
             X = np.tile(X, (Y.shape[1], 1)).transpose()
 


### PR DESCRIPTION
## Description
We had a reshape block for the specific case of `line` where `Y` was an Mx1 array. To my knowledge, it would appear that all this reshape did was allow `line` to take in what we'd consider to be improperly formatted values from users and reshape it into a form that they can see. Unfortunately it also broke the legitimate case of wanting to plot multiple single points at the same time due to the behavior of reshape. Namely, reshaping an Mx1 array by M produces an M array rather than an Mx1 array. This fixes the issue by forcing the Mx1 shape to become 1xM, which should be properly handled in both the 'multiple single points' and misshapen array cases.

## Motivation and Context
Fixes #539

## How Has This Been Tested?
Tested the demo, which works exactly the same.

Tested the following snippet:

```python
import visdom
import numpy as np
vis = visdom.Visdom()
win = vis.line(X=np.array((1,)), Y=np.array(((1,),(3,))))
vis.line(X=np.array((2,)), Y=np.array(((2,),(4,))), update='append', win=win)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
