### PR TITLE
Logging tracebacks during errors on the server

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -383,6 +383,9 @@ class BaseHandler(tornado.web.RequestHandler):
 
     def write_error(self, status_code, **kwargs):
         logging.error("ERROR: %s: %s" % (status_code, kwargs))
+        if "exc_info" in kwargs:
+            logging.info('Traceback: {}'.format(
+                traceback.format_exception(*kwargs["exc_info"])))
         if self.settings.get("debug") and "exc_info" in kwargs:
             logging.error("rendering error page")
             import traceback


### PR DESCRIPTION
## Description
Right now when an error occurs on the visdom server we print the error, but no details about what actually happened or the traceback. This makes it particularly hard to debug when something goes wrong and where the error happened when it happens. This change adds a print for the exception information so that we can see what happened. 

## Motivation and Context
As in the case of #560, server issues are currently very hard to debug without this information.