### PR TITLE
Warning on None opts that can't be None

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -252,6 +252,14 @@ def _dashCheck(dash, K):
 
 
 def _assert_opts(opts):
+    remove_nones = ['title']
+    for to_remove in remove_nones:
+        if to_remove in opts and opts[to_remove] is None:
+            logger.warn(
+                'None-incompatible opt {} was provided None value '
+                'and was thus ignored'.format(to_remove))
+            del opts[to_remove]
+
     if opts.get('color'):
         assert isstr(opts.get('color')), 'color should be a string'
 


### PR DESCRIPTION
## Description
Certain options, namely `title`, cause a crash when a None value is provided to the opts dict. This PR makes it so these opts are removed from the dict, allowing the plot to not crash everything. I warn when this occurs though, as it is more likely to be the result of a bug than someone intentionally passing None to that opt value.

## Motivation and Context
Fixes #563.

## How Has This Been Tested?
```
>>> vis.line(X=np.array((2,)), Y=np.array(((2,))), opts={'title': None})
WARNING:visdom:None-incompatible opt title was provided None value and was thus ignored
'window_37317b92756306'
```