### PR TITLE
Fixing matplot resizable option with bs4 installed

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -840,13 +840,17 @@ class Visdom(object):
 
         # show SVG:
         if 'height' not in opts:
-            height = height or re.search('height\="([0-9\.]*)pt"', svg)
+            height = height or re.search(r'height\="([0-9\.]*)pt"', svg)
             if height is not None:
-                opts['height'] = 1.4 * int(math.ceil(float(height.group(1))))
+                if not isstr(height):
+                    height = height.group(1)
+                opts['height'] = 1.4 * int(math.ceil(float(height)))
         if 'width' not in opts:
-            width = width or re.search('width\="([0-9\.]*)pt"', svg)
+            width = width or re.search(r'width\="([0-9\.]*)pt"', svg)
             if width is not None:
-                opts['width'] = 1.35 * int(math.ceil(float(width.group(1))))
+                if not isstr(width):
+                    width = width.group(1)
+                opts['width'] = 1.35 * int(math.ceil(float(width)))
         return self.svg(svgstr=svg, opts=opts, env=env, win=win)
 
     def plotlyplot(self, figure, win=None, env=None):


### PR DESCRIPTION
## Description
The matplot resizable option would break under bs4 as the produced values for height and width would already be strings rather than re match objects. This checks before trying to extract a height or width. 

## Motivation and Context
Fixes #579.
