### PR TITLE
Visdom offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The python visdom client takes a few options:
 - `username`: username to use for authentication, if server started with `-enable_login` (default: `None`)
 - `password`: password to use for authentication, if server started with `-enable_login` (default: `None`)
 - `proxies`: Dictionary mapping protocol to the URL of the proxy (e.g. {`http`: `foo.bar:3128`}) to be used on each Request. (default: `None`)
+- `offline`: Flag to run visdom in offline mode, where all requests are logged to file rather than to the server. Requires `log_to_filename` is set. In offline mode, all visdom commands that don't create or update plots will simply return `True`. (default: `False`)
 
 Other options are either currently unused (endpoint, ipv6) or used for internal functionality (send allows the visdom server to replicate events for the lua client).
 


### PR DESCRIPTION
## Description
For cases where it doesn't make sense to be logging to a remote server, or where a server cannot be running, it is reasonable to want to run visdom in a form that is logging to file only, then being able to replay those logs later on from a different location. This adds an option for visdom to run in `offline` mode, and lets those logs be played back later. In order to implement this, any commands that aren't modifications to a window (which would formerly return the window id on success) will always return True in offline mode.

## Motivation and Context
Fixes #570.

## How Has This Been Tested?
```python
import visdom
vis = visdom.Visdom(log_to_filename='/tmp/test_to_and_from_log', offline=True)
vis.text('Hello world')
vis = visdom.Visdom()  # new visdom that actually connects to the server
vis.replay_log('/tmp/test_to_and_from_log')
```

Also ran `demo.py` to see if there were any errors, everything rendered normally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
