### PR TITLE
Adds autoplay and loop options to vis.video()

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1075,9 +1075,13 @@ class Visdom(object):
         The function does not support any plot-specific `opts`. The following video `opts` are supported:
 
         - `opts.fps`: FPS for the video (`integer` > 0; default = 25)
+        - `opts.autoplay`: whether to autoplay the video when it's ready (`boolean`; default = `false`)
+        - `opts.loop`: whether to loop the video (`boolean`; default = `false`)
         """
         opts = {} if opts is None else opts
         opts['fps'] = opts.get('fps', 25)
+        opts['loop'] = opts.get('loop', False)
+        opts['autoplay'] = opts.get('autoplay', False)
         _title2str(opts)
         _assert_opts(opts)
         assert tensor is not None or videofile is not None, \
@@ -1125,13 +1129,15 @@ class Visdom(object):
         mimetype = mimetypes.get(extension)
         assert mimetype is not None, 'unknown video type: %s' % extension
 
+        flags = ' '.join([k for k in ('autoplay', 'loop') if opts[k]])
+
         bytestr = loadfile(videofile)
         videodata = """
-            <video controls>
+            <video controls %s>
                 <source type="video/%s" src="data:video/%s;base64,%s">
                 Your browser does not support the video tag.
             </video>
-        """ % (mimetype, mimetype, base64.b64encode(bytestr).decode('utf-8'))
+        """ % (flags, mimetype, mimetype, base64.b64encode(bytestr).decode('utf-8'))
         return self.text(text=videodata, win=win, env=env, opts=opts)
 
     def update_window_opts(self, win, opts, env=None):


### PR DESCRIPTION
## Description
Adds two options to enable/disable autoplaying and looping in videos.

## Motivation and Context
Currently videos neither autoplay nor loop. Since reinforcement learning videos are typically a few seconds long, this means every epoch leads to an extra click. With these flags, it's one click less.

## How Has This Been Tested?
No tests; changes are simple and don't change existing behaviour. 

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
