### PR TITLE
Change rand_id seed to random uuid object instead of system time

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -23,6 +23,7 @@ import math
 import os
 import time
 import traceback
+import uuid
 from os.path import expanduser
 from collections import OrderedDict, Mapping, Sequence
 from six import string_types
@@ -56,7 +57,7 @@ def check_auth(f):
 
 
 def get_rand_id():
-    return str(hex(int(time.time() * 10000000))[2:])
+    return str(uuid.uuid4())
 
 
 def ensure_dir_exists(path):


### PR DESCRIPTION
## Description
Switched the random seed used to generate window ids from being based on current system time with the python uuid module.

## Motivation and Context
Creating multiple windows in quick succession can lead to the same window id being generated for separate windows, causing issues such as:
[Spiky Graphs Due to Appending Multiple Data Points to Same Window](https://github.com/facebookresearch/visdom/issues/603)
[Less Than Expected Amount of Windows Plotted Due to ID Collision](https://github.com/facebookresearch/visdom/issues/604)

## How Has This Been Tested?
Testing Environment: Fresh Python 3.7 Conda Environment, visdom built from source.

Test function created 10 plots in quick succession, and updated over 10 time points in quick succession.

Also ran demo.py with no impact on existing features.

## Screenshots:
No more spiking artifacts, expected amount of plots created.
![image](https://user-images.githubusercontent.com/10430633/55935183-f57ee400-5c00-11e9-9392-f5303d1a8247.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
