### PR TITLE
Fix vis.close with win=None

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -571,7 +571,9 @@ class Visdom(object):
         if not self.send:
             return msg, endpoint
 
-        if 'win' in msg and msg['win'] is None:
+        # For /close, win=None means closing all windows. So do not substitute
+        # in that case.
+        if 'win' in msg and msg['win'] is None and endpoint is not 'close':
             msg['win'] = 'window_' + get_rand_id()
 
         if not from_log:


### PR DESCRIPTION
## Description
In `_send`, `None` win get's replaced with a random window id, and thus breaking `vis.close(win=None)` functionality for closing all windows.

## How Has This Been Tested?
Locally. Verified that the fix works.=

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
