### PR TITLE
Updating gitignore for static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@ dist/
 visdom*.tgz
 visdom.egg-info/
 setup.cfg
-py/static/fonts/
-py/static/css/
-py/static/js/*.min.js
-py/static/js/mathjax-MathJax.js
-py/static/version.built
+py/visdom/static/fonts/
+py/visdom/static/css/
+py/visdom/static/js/*.min.js
+py/visdom/static/js/mathjax-MathJax.js
+py/visdom/static/js/sjcl.js
+py/visdom/static/version.built


### PR DESCRIPTION
Realized that ever since #281 our `.gitignore` hasn't actually covered static files properly, leading to needing to add files manually when committing things. This properly updates the paths.
