### PR TITLE
Save image as jpg if jpgquality parameter is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ that contains the image.
 
 The following `opts` are supported:
 
-- `jpgquality`: JPG quality (`number` 0-100; default = 100)
+- `jpgquality`: JPG quality (`number` 0-100). If defined image will be saved as JPG to reduce file size. If not defined image will be saved as PNG.
 - `caption`: Caption for the image
 - `store_history`: Keep all images stored to the same window and attach a slider to the bottom that will let you select the image to view. You must always provide this opt when sending new images to an image with history.
 
@@ -332,7 +332,7 @@ The following arguments and `opts` are supported:
 
 - `nrow`: Number of images in a row
 - `padding`: Padding around the image, equal padding around all 4 sides
-- `opts.jpgquality`: JPG quality (`number` 0-100; default = 100)
+- `opts.jpgquality`: JPG quality (`number` 0-100). If defined image will be saved as JPG to reduce file size. If not defined image will be saved as PNG.
 - `opts.caption`: Caption for the image
 
 #### vis.text

--- a/example/demo.py
+++ b/example/demo.py
@@ -97,6 +97,12 @@ try:
         opts=dict(title='Random!', caption='How random.'),
     )
 
+    # image demo save as jpg
+    viz.image(
+        np.random.rand(3, 512, 256),
+        opts=dict(title='Random image as jpg!', caption='How random as jpg.', jpgquality=50),
+    )
+
     # image history demo
     viz.image(
         np.random.rand(3, 512, 256),

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -955,12 +955,19 @@ class Visdom(object):
         img = np.transpose(img, (1, 2, 0))
         im = Image.fromarray(img)
         buf = BytesIO()
-        im.save(buf, format='PNG')
+        image_type = 'png'
+        imsave_args = {}
+        if 'jpgquality' in opts:
+            image_type = 'jpeg'
+            imsave_args['quality'] = opts['jpgquality']
+
+        im.save(buf, format=image_type.upper(), **imsave_args)
+
         b64encoded = b64.b64encode(buf.getvalue()).decode('utf-8')
 
         data = [{
             'content': {
-                'src': 'data:image/png;base64,' + b64encoded,
+                'src': 'data:image/' + image_type + ';base64,' + b64encoded,
                 'caption': opts.get('caption'),
             },
             'type': 'image_history' if opts.get('store_history') else 'image',


### PR DESCRIPTION
## Description
If user set jpgquality parameter visdom will save image as jpg with this quality instead of PNG.
Related PR which switch JPG to PNG #246 

## Motivation and Context
If you use big images you may want to reduce their size to speed up loading visdom pages. Now images saves as png and jpgquality parameter take no effect.

## How Has This Been Tested?
It has been tested with example.py

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.