### PR TITLE
Append events in local log fix

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1231,8 +1231,12 @@ class Visdom(object):
             assert win is not None, 'Must define a window to update'
 
             if update == 'append':
-                if win is None or not self.win_exists(win, env):
+                if win is None:
                     update = None
+                elif not self.offline:
+                    exists = self.win_exists(win, env)
+                    if exists is False:
+                        update = None
 
             # case when X is 1 dimensional and corresponding values on y-axis
             # are passed in parameter Y

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -731,7 +731,14 @@ class UpdateHandler(BaseHandler):
         eid = extract_eid(args)
 
         if args['win'] not in handler.state[eid]['jsons']:
-            handler.write('win does not exist')
+            # Append to a window that doesn't exist attempts to create
+            # that window
+            append = args.get('append')
+            if append:
+                p = window(args)
+                register_window(handler, p, eid)
+            else:
+                handler.write('win does not exist')
             return
 
         p = handler.state[eid]['jsons'][args['win']]
@@ -846,6 +853,7 @@ class EnvStateHandler(BaseHandler):
         )
         self.wrap_func(self, args)
 
+
 class ForkEnvHandler(BaseHandler):
     def initialize(self, app):
         self.app = app
@@ -872,6 +880,7 @@ class ForkEnvHandler(BaseHandler):
             tornado.escape.to_basestring(self.request.body)
         )
         self.wrap_func(self, args)
+
 
 class HashHandler(BaseHandler):
     def initialize(self, app):


### PR DESCRIPTION
As surfaced in #624, there are some issues in the interactions between local logging and append, especially when working in offline mode. This is the fix.

Fixes #624

## Description
The core of the interaction here that wasn't working properly was that append events were not being properly handled due to `win_exists` not successfully returning that a window had been created. This now stores append events into the logs as such both when offline and when `win_exists` returns none (failed connection). In order to handle the fact that it's possible that append events may be sent to the server on a replay_log event, I've also cased `UpdateHandler` to be able to create a window during an append event if none existed already.

## How Has This Been Tested?
Ran the test case in #624

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
