### PR TITLE
Fixing login base_url bug

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1242,6 +1242,7 @@ class IndexHandler(BaseHandler):
         self.env_path = app.env_path
         self.login_enabled = app.login_enabled
         self.user_credential = app.user_credential
+        self.base_url = app.base_url if app.base_url != '' else '/'
 
     def get(self, args, **kwargs):
         items = gather_envs(self.state, env_path=self.env_path)
@@ -1261,7 +1262,8 @@ class IndexHandler(BaseHandler):
                 'login.html',
                 user=getpass.getuser(),
                 items=items,
-                active_item=''
+                active_item='',
+                base_url=self.base_url
             )
 
     def post(self, arg, **kwargs):

--- a/py/visdom/static/login.html
+++ b/py/visdom/static/login.html
@@ -45,11 +45,11 @@ LICENSE file in the root directory of this source tree.
               var dataToSend = JSON.stringify(data);
               $.ajax(
                       {
-                          url: '/',
+                          url: '{{base_url}}',
                           type: 'POST',
                           data: dataToSend,
                           success:function() {
-                            window.location.replace("/")
+                            window.location.replace("{{base_url}}")
                           },
                           error: function () {
                             $("#errorMessage").text("Invalid Login Information");


### PR DESCRIPTION
## Description
Adds templating to the login page that allows it to redirect to the correct base_url

## Motivation and Context
Fixes #630

## How Has This Been Tested?
Ran the server with `python -m visdom.server -enable_login -base_url '/test'`, logged in, and was redirected to the correct page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
