### PR TITLE
[tsne] Auto-scale perplexity, enforce 22 pts min on UI, add loading screen on first call

### DIFF
--- a/js/EmbeddingsPane.js
+++ b/js/EmbeddingsPane.js
@@ -87,22 +87,38 @@ class EmbeddingsPane extends React.Component {
   render() {
     return (
       <Pane {...this.props} handleDownload={this.handleDownload}>
-        <Scene
-          key={
-            this.props.height +
-            '===' +
-            this.props.width +
-            '===' +
-            this.props.content.data.length
-          }
-          content={this.props.content}
-          height={this.props.height}
-          width={this.props.width}
-          onSelect={this.onEntitySelection}
-          onRegionSelection={this.onRegionSelection}
-          onGoBack={this.onGoBack}
-          interactive={this.props.isFocused}
-        />
+        {this.props.content.isLoading ? (
+          <div
+            style={{
+              width: this.props.width + 'px',
+              height: this.props.height + 'px',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              textAlign: 'center',
+              padding: '5px 10px',
+            }}
+          >
+            Generating embeddings visualization...
+          </div>
+        ) : (
+          <Scene
+            key={
+              this.props.height +
+              '===' +
+              this.props.width +
+              '===' +
+              this.props.content.data.length
+            }
+            content={this.props.content}
+            height={this.props.height}
+            width={this.props.width}
+            onSelect={this.onEntitySelection}
+            onRegionSelection={this.onRegionSelection}
+            onGoBack={this.onGoBack}
+            interactive={this.props.isFocused}
+          />
+        )}
       </Pane>
     );
   }

--- a/js/EmbeddingsPane.js
+++ b/js/EmbeddingsPane.js
@@ -610,7 +610,8 @@ class Scene extends React.Component {
 
 class LassoSelection extends React.Component {
   componentDidMount() {
-    var lassoInstance = lasso()
+    var lassoInstance = lasso();
+    lassoInstance
       .on('end', polygon => {
         this.props.camera.updateMatrixWorld();
 
@@ -637,6 +638,10 @@ class LassoSelection extends React.Component {
           polygonContains(polygon, point.test)
         );
         console.log(selected.map(pt => pt.ref.idx));
+        if (selected.length <= 21) {
+          lassoInstance.reset();
+          return;
+        }
         this.props.onRegionSelection(selected.map(pt => pt.ref.idx));
       })
       .on('start', null);

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -50,7 +50,12 @@ try:
     import visdom.extra_deps.bhtsne.bhtsne as bhtsne
 
     def do_tsne(X):
-        Y = bhtsne.run_bh_tsne(X, initial_dims=X.shape[1], verbose=True)
+        num_entities = len(X)
+
+        # the number of entities provided must be 
+        perplexity = 50 if num_entities >= 150 else \
+            num_entities // 3 if num_entities >= 21 else 7
+        Y = bhtsne.run_bh_tsne(X, initial_dims=X.shape[1], perplexity=perplexity, verbose=True)
         xmin, xmax = min(Y[:, 0]), max(Y[:, 0])
         ymin, ymax = min(Y[:, 1]), max(Y[:, 1])
         normx = ((Y[:, 0] - xmin) / (xmax - xmin))*2-1

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -52,7 +52,7 @@ try:
     def do_tsne(X):
         num_entities = len(X)
 
-        # the number of entities provided must be 
+        # the number of entities provided must be at least 3x the perplexity 
         perplexity = 50 if num_entities >= 150 else \
             num_entities // 3 if num_entities >= 21 else 7
         Y = bhtsne.run_bh_tsne(X, initial_dims=X.shape[1], perplexity=perplexity, verbose=True)

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1073,6 +1073,17 @@ class Visdom(object):
         _title2str(opts)
         _assert_opts(opts)
 
+        loading_message = {
+            'content': {'isLoading': True},
+            'type': 'embeddings',
+        }
+        win = self._send({
+            'data': [loading_message],
+            'win': win,
+            'eid': env,
+            'opts': opts,
+        }, endpoint='events')
+
         Y = do_tsne(features)
 
         label_set = list(set(labels))

--- a/py/visdom/static/js/main.js
+++ b/py/visdom/static/js/main.js
@@ -44596,7 +44596,21 @@
 	      return _react2.default.createElement(
 	        Pane,
 	        _extends({}, this.props, { handleDownload: this.handleDownload }),
-	        _react2.default.createElement(Scene, {
+	        this.props.content.isLoading ? _react2.default.createElement(
+	          'div',
+	          {
+	            style: {
+	              width: this.props.width + 'px',
+	              height: this.props.height + 'px',
+	              display: 'flex',
+	              justifyContent: 'center',
+	              alignItems: 'center',
+	              textAlign: 'center',
+	              padding: '5px 10px'
+	            }
+	          },
+	          'Generating embeddings visualization...'
+	        ) : _react2.default.createElement(Scene, {
 	          key: this.props.height + '===' + this.props.width + '===' + this.props.content.data.length,
 	          content: this.props.content,
 	          height: this.props.height,

--- a/py/visdom/static/js/main.js
+++ b/py/visdom/static/js/main.js
@@ -45176,7 +45176,8 @@
 	    value: function componentDidMount() {
 	      var _this7 = this;
 
-	      var lassoInstance = (0, _lasso2.default)().on('end', function (polygon) {
+	      var lassoInstance = (0, _lasso2.default)();
+	      lassoInstance.on('end', function (polygon) {
 	        _this7.props.camera.updateMatrixWorld();
 
 	        var points = _this7.props.points.map(function (point) {
@@ -45203,6 +45204,10 @@
 	        console.log(selected.map(function (pt) {
 	          return pt.ref.idx;
 	        }));
+	        if (selected.length <= 21) {
+	          lassoInstance.reset();
+	          return;
+	        }
 	        _this7.props.onRegionSelection(selected.map(function (pt) {
 	          return pt.ref.idx;
 	        }));


### PR DESCRIPTION
This will be merged into the WIP t-SNE branch #611 

It addresses a few things we discussed before:
- a loading screen on the initial python call to `vis.embeddings` (I was not able to get this to work on lasso selection however)
- a minimum of 22 points must be lassoed on the UI to run embeddings
- perplexity will be autoscaled for any # of points 22 and above such that perplexity = floor(# of points / 3), capping at 50