### PR TITLE
Fix display empty error when running visdom with base_url and enable_login …

### DIFF
--- a/example/demo.py
+++ b/example/demo.py
@@ -534,10 +534,23 @@ if __name__ == '__main__':
     parser.add_argument('-server', metavar='server', type=str,
                         default=DEFAULT_HOSTNAME,
                         help='Server address of the target to run the demo on.')
+    parser.add_argument('-base_url', metavar='base_url', type=str,
+                    default='/',
+                    help='Base Url.')
+    parser.add_argument('-username', metavar='username', type=str,
+                    default='',
+                    help='username.')
+    parser.add_argument('-password', metavar='password', type=str,
+                    default='',
+                    help='password.')
+    parser.add_argument('-use_incoming_socket', metavar='use_incoming_socket', type=bool,
+                    default=True,
+                    help='use_incoming_socket.')
     FLAGS = parser.parse_args()
 
     try:
-        viz = Visdom(port=FLAGS.port, server=FLAGS.server)
+        viz = Visdom(port=FLAGS.port, server=FLAGS.server, base_url=FLAGS.base_url, username=FLAGS.username, password=FLAGS.password, \
+                use_incoming_socket=FLAGS.use_incoming_socket)
         run_demo(viz)
     except Exception as e:
         print(

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -468,7 +468,7 @@ class Visdom(object):
         if self.proxies:
             sess.proxies.update(self.proxies)
         if self.username:
-            resp = sess.post("%s:%s" % (self.server, self.port), json=dict(
+            resp = sess.post("%s:%s%s" % (self.server, self.port, self.base_url), json=dict(
                 username=self.username,
                 password=self.password))
             if resp.status_code != requests.codes.ok:


### PR DESCRIPTION
## Description
py/visdom/__init__.py. In line 471,
`resp = sess.post("%s:%s" % (self.server, self.port)`
was replaced with:
`resp = sess.post("%s:%s%s" % (self.server, self.port, self.base_url)` j

example/demo.py has been modified to take into account additional parameters :
`
 parser.add_argument('-base_url', metavar='base_url', type=str,
                    default='/',
                    help='Base Url.')
    parser.add_argument('-username', metavar='username', type=str,
                    default='',
                    help='username.')
    parser.add_argument('-password', metavar='password', type=str,
                    default='',
                    help='password.')
    parser.add_argument('-use_incoming_socket', metavar='use_incoming_socket', type=bool,
                    default=True,
                    help='use_incoming_socket.')
`
and:
`viz = Visdom(port=FLAGS.port, server=FLAGS.server, base_url=FLAGS.base_url, username=FLAGS.username, password=FLAGS.password,
use_incoming_socket=FLAGS.use_incoming_socket)
`   

## Motivation and Context
When the enable_login and base_url are used at the same time when starting visdom, the graphics didn't display in the browser.

## How Has This Been Tested?
1. Start visdom with:
     visdom -enable_login -base_url /my_base_url
2. Open a browser at http://127.0.0.1:8097/my_base_url
3. In a shell command, run:
    python example/demo.py -port 8097 -server "127.0.0.1" -use_incoming_socket True -base_url "/my_base_url" -username "tom" -password "tom"
4. All the graphical objects are displayed in the browser.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
