### PR TITLE
Fix NumPy deprecation warning

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1665,8 +1665,8 @@ class Visdom(object):
 
         assert X.ndim == 2, 'data should be two-dimensional'
         opts = {} if opts is None else opts
-        opts['xmin'] = opts.get('xmin', np.asscalar(np.nanmin(X)))
-        opts['xmax'] = opts.get('xmax', np.asscalar(np.nanmax(X)))
+        opts['xmin'] = opts.get('xmin', np.nanmin(X).item())
+        opts['xmax'] = opts.get('xmax', np.nanmax(X).item())
         opts['colormap'] = opts.get('colormap', 'Viridis')
         _title2str(opts)
         _assert_opts(opts)


### PR DESCRIPTION
The `np.asscalar` function was deprecated in favor of the `np.ndarray.item` method since NumPy v1.16. `setup.py` specifies version >=1.8 and `item` is present on this version.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
