### PR TITLE
Issue 659: Enable login env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ The following options can be provided to the server:
 8. `-force_new_cookie` : Flag to reset the secure cookie used by the server, invalidating current login cookies.
 Requires `-enable_login`.
 
+When `-enable_login` flag is provided, the server asks user to input credentials using terminal prompt. Alternatevily,
+you can setup `VISDOM_USE_ENV_CREDENTIALS` env variable, and then provide your username and password via
+`VISDOM_USERNAME` and `VISDOM_PASSWORD` env variables without manually interacting with the terminal. This setup
+is useful in case if you would like to launch `visdom` server from bash script, or from Jupyter notebook.
+```bash
+VISDOM_USERNAME=username
+VISDOM_PASSWORD=password
+VISDOM_USE_ENV_CREDENTIALS=1 visdom -enable_login
+```
+You can also use `VISDOM_COOKIE` variable to provide cookies value if the cookie file wasn't generated, or the 
+flag `-force_new_cookie` was set.
 
 #### Python example
 ```python

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1892,13 +1892,14 @@ def main(print_func=None):
         if need_to_set_cookie:
             if use_env:
                 cookie_var = 'VISDOM_COOKIE'
-                env_cookie = os.environ(cookie_var)
+                env_cookie = os.environ.get(cookie_var)
                 if env_cookie is None:
                     print(
                         'The cookie file is not found. Please setup {0} env '
                         'variable to provide a cookie value, or unset {1} env '
-                        'variable to input credentials and cookie via command'
+                        'variable to input credentials and cookie via command '
                         'line prompt.'.format(cookie_var, enable_env_login))
+                    sys.exit(1)
             else:
                 env_cookie = None
             set_cookie(env_cookie)

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -115,9 +115,12 @@ def extract_eid(args):
     return escape_eid(eid)
 
 
-def set_cookie():
+def set_cookie(value=None):
     """Create cookie secret key for authentication"""
-    cookie_secret = input("Please input your cookie secret key here: ")
+    if value is not None:
+        cookie_secret = value
+    else:
+        cookie_secret = input("Please input your cookie secret key here: ")
     with open(DEFAULT_ENV_PATH + "COOKIE_SECRET", "w") as cookie_file:
         cookie_file.write(cookie_secret)
 
@@ -1863,13 +1866,13 @@ def main(print_func=None):
             password = os.environ.get(password_var)
             if not (username and password):
                 print(
-                    "*** Warning ***\n"
-                    "You have set the {0} env variable but probably "
-                    "forgot to setup up one (or both) {{ {1}, {2} }} "
-                    "variables.\nYou should setup these variables with "
-                    "proper username and password to enable logging. Try to "
-                    "setup the variables, or unset {0} to input credentials "
-                    "via CLI instead.\n"
+                    '*** Warning ***\n'
+                    'You have set the {0} env variable but probably '
+                    'forgot to setup one (or both) {{ {1}, {2} }} '
+                    'variables.\nYou should setup these variables with '
+                    'proper username and password to enable logging. Try to '
+                    'setup the variables, or unset {0} to input credentials '
+                    'via command line prompt instead.\n'
                     .format(enable_env_login, username_var, password_var))
                 sys.exit(1)
 
@@ -1882,10 +1885,24 @@ def main(print_func=None):
             "password": hash_password(hash_password(password))
         }
 
-        if not os.path.isfile(DEFAULT_ENV_PATH + "COOKIE_SECRET"):
-            set_cookie()
-        elif FLAGS.force_new_cookie:
-            set_cookie()
+        need_to_set_cookie = (
+            not os.path.isfile(DEFAULT_ENV_PATH + "COOKIE_SECRET")
+            or FLAGS.force_new_cookie)
+
+        if need_to_set_cookie:
+            if use_env:
+                cookie_var = 'VISDOM_COOKIE'
+                env_cookie = os.environ(cookie_var)
+                if env_cookie is None:
+                    print(
+                        'The cookie file is not found. Please setup {0} env '
+                        'variable to provide a cookie value, or unset {1} env '
+                        'variable to input credentials and cookie via command'
+                        'line prompt.'.format(cookie_var, enable_env_login))
+            else:
+                env_cookie = None
+            set_cookie(env_cookie)
+
     else:
         user_credential = None
 

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -21,6 +21,7 @@ import jsonpatch
 import logging
 import math
 import os
+import sys
 import time
 import traceback
 import uuid
@@ -1853,8 +1854,28 @@ def main(print_func=None):
     logging.getLogger().setLevel(logging_level)
 
     if FLAGS.enable_login:
-        username = input("Please input your username: ")
-        password = getpass.getpass(prompt="Please input your password: ")
+        enable_env_login = 'VISDOM_USE_ENV_CREDENTIALS'
+        use_env = os.environ.get(enable_env_login, False)
+        if use_env:
+            username_var = 'VISDOM_USERNAME'
+            password_var = 'VISDOM_PASSWORD'
+            username = os.environ.get(username_var)
+            password = os.environ.get(password_var)
+            if not (username and password):
+                print(
+                    "*** Warning ***\n"
+                    "You have set the {0} env variable but probably "
+                    "forgot to setup up one (or both) {{ {1}, {2} }} "
+                    "variables.\nYou should setup these variables with "
+                    "proper username and password to enable logging. Try to "
+                    "setup the variables, or unset {0} to input credentials "
+                    "via CLI instead.\n"
+                    .format(enable_env_login, username_var, password_var))
+                sys.exit(1)
+
+        else:
+            username = input("Please input your username: ")
+            password = getpass.getpass(prompt="Please input your password: ")
 
         user_credential = {
             "username": username,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR addresses the feature discussed on #659. The idea is to enable setting up login credentials not only using the command line prompt but also via environment variables.

## Motivation and Context
Providing credentials via CLI is not too convenient when writing automation scripts that should launch `visdom` server without manual interaction, or in any other cases when it would be more simple to set up credentials without prompt.

Relevant issue: #659

## How Has This Been Tested?
It is a bit challenging task to write a proper unit test for CLI parameters so the introduced changes were tested running the `server.py` with various settings to make sure that the old behavior is not broken, and the new one works as expected. Below shown the commands and their output

1. Setup credentials via command prompt. (Default behavior).
```bash
visdom -enable_login

Checking for scripts.
Please input your username: username
Please input your password:
Please input your cookie secret key here: cookie
It's Alive!
INFO:root:Application Started
You can navigate to http://localhost:8097
```
2. Credentials via env variables requested but not provided.
```bash
VISDOM_USE_ENV_CREDENTIALS=1 visdom -enable_login

Checking for scripts.
*** Warning ***
You have set the VISDOM_USE_ENV_CREDENTIALS env variable but probably forgot to setup one (or both) { VISDOM_USERNAME, VISDOM_PASSWORD } variables.
You should setup these variables with proper username and password to enable logging. Try to setup the variables, or unset VISDOM_USE_ENV_CREDENTIALS to input credentials via command line prompt instead.
```

3. Credentials env variables provided,  but not for a cookie when it is requried.
```bash
export VISDOM_USERNAME=username
export VISDOM_PASSWORD=password
VISDOM_USE_ENV_CREDENTIALS=1 visdom -enable_login -force_new_cookie

Checking for scripts.
The cookie file is not found. Please setup VISDOM_COOKIE env variable to provide a cookie value, or unset VISDOM_USE_ENV_CREDENTIALS env variable to input credentials and cookie via command line prompt.
```

4.  Credentials env variables provided,  but not for a cookie when it was already created.
```bash
export VISDOM_USERNAME=username
export VISDOM_PASSWORD=password
VISDOM_USE_ENV_CREDENTIALS=1 visdom -enable_login

Checking for scripts.
It's Alive!
INFO:root:Application Started
You can navigate to http://localhost:8097
```

5. Env variables set everything.
```bash
export VISDOM_USERNAME=username
export VISDOM_PASSWORD=password
export VISDOM_COOKIE=cookie
VISDOM_USE_ENV_CREDENTIALS=1 visdom -enable_login -force_new_cookie

Checking for scripts.
It's Alive!
INFO:root:Application Started
You can navigate to http://localhost:8097
```
Every scenario seems to work properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.