### PR TITLE
Deprecating Python 2 support in visdom

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Using the view dropdown it is possible to select previously saved views, restori
 
 ## Setup
 
-Requires Python 2.7/3 (and optionally Torch7)
+Requires Python 3 (and optionally Torch7)
 
 ```bash
 # Install Python server and client from pip
@@ -204,7 +204,7 @@ VISDOM_USERNAME=username
 VISDOM_PASSWORD=password
 VISDOM_USE_ENV_CREDENTIALS=1 visdom -enable_login
 ```
-You can also use `VISDOM_COOKIE` variable to provide cookies value if the cookie file wasn't generated, or the 
+You can also use `VISDOM_COOKIE` variable to provide cookies value if the cookie file wasn't generated, or the
 flag `-force_new_cookie` was set.
 
 #### Python example

--- a/example/demo-properties.py
+++ b/example/demo-properties.py
@@ -1,13 +1,10 @@
+#!/usr/bin/env python3
+
 # Copyright 2017-present, Facebook, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from visdom import Visdom
 import time

--- a/example/demo.py
+++ b/example/demo.py
@@ -1,13 +1,10 @@
+#!/usr/bin/env python3
+
 # Copyright 2017-present, Facebook, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from visdom import Visdom
 import argparse
@@ -16,7 +13,7 @@ import math
 import os.path
 import time
 import tempfile
-from six.moves import urllib
+import urllib
 
 
 def run_demo(viz):

--- a/example/mnist-embeddings.py
+++ b/example/mnist-embeddings.py
@@ -1,19 +1,16 @@
+#!/usr/bin/env python3
+
 # Copyright 2017-present, Facebook, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import visdom
 import numpy as np
 from PIL import Image  # type: ignore
 import base64 as b64  # type: ignore
-from six import BytesIO
+from io import BytesIO
 import sys
 
 try:

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -41,7 +41,7 @@ except ImportError:
     BS4_AVAILABLE = False
 
 import sys
-assert sys.version_info[0] < 3, 'To use visdom with python 2, downgrade to v0.1.8.9'
+assert sys.version_info[0] >= 3, 'To use visdom with python 2, downgrade to v0.1.8.9'
 
 try:
     # TODO try to import https://github.com/CannyLab/tsne-cuda first? will be

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -981,6 +981,7 @@ class UpdateHandler(BaseHandler):
                 selected_not_neg = max(0, selected)
                 selected_exists = min(len(p['content'])-1, selected_not_neg)
                 p['selected'] = selected_exists
+            return p
 
         pdata = p['content']['data']
 

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -54,7 +54,7 @@ _seen_warnings = set()
 
 MAX_SOCKET_WAIT = 15
 
-assert sys.version_info[0] < 3, 'To use visdom with python 2, downgrade to v0.1.8.9'
+assert sys.version_info[0] >= 3, 'To use visdom with python 2, downgrade to v0.1.8.9'
 
 
 def warn_once(msg, warningtype=None):

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2017-present, Facebook, Inc.
 # All rights reserved.
 #
@@ -5,11 +7,6 @@
 # LICENSE file in the root directory of this source tree.
 
 """Server"""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import argparse
 import copy
@@ -29,10 +26,11 @@ import warnings
 from os.path import expanduser
 from collections import OrderedDict
 try:
+    # for after python 3.8
     from collections.abc import Mapping, Sequence
 except ImportError:
+    # for python 3.7 and below
     from collections import Mapping, Sequence
-from six import string_types
 
 import visdom
 from zmq.eventloop import ioloop
@@ -55,6 +53,8 @@ COMPACT_SEPARATORS = (',', ':')
 _seen_warnings = set()
 
 MAX_SOCKET_WAIT = 15
+
+assert sys.version_info[0] < 3, 'To use visdom with python 2, downgrade to v0.1.8.9'
 
 
 def warn_once(msg, warningtype=None):
@@ -912,7 +912,7 @@ def recursive_order(node):
     elif isinstance(node, Sequence):
         if isinstance(node, (bytes,)):
             return node
-        elif isinstance(node, string_types):
+        elif isinstance(node, (str,)):
             return node
         else:
             return [recursive_order(item) for item in node]
@@ -1729,8 +1729,8 @@ def download_scripts(proxies=None, install_dir=None):
             os.makedirs(directory)
 
     # set up proxy handler:
-    from six.moves.urllib import request
-    from six.moves.urllib.error import HTTPError, URLError
+    from urllib import request
+    from urllib.error import HTTPError, URLError
     handler = request.ProxyHandler(proxies) if proxies is not None \
         else request.BaseHandler()
     opener = request.build_opener(handler)


### PR DESCRIPTION
## Description
As a first step towards modernizing the visdom codebase, I'm freeing us from the shackles of python 2 compatibility. Version `v0.1.8.9` was tagged as the last version with python support, and will be left for any users that want to use python 2 with visdom. Future enhancements will be python 3 only.

## Motivation and Context
Python 2 support has become something of a burden (from testing to maintenance to merging new code - #647 and #595 have been blocked by internal python3 issues for a while now). Now 

## How Has This Been Tested?
Run `demo.py` on python3, everything works well! Run `demo.py` on python2, get a notice to downgrade.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
