### PR TITLE
Marker border line width override (#623)

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,14 +438,15 @@ If updating a single trace, use `name` to specify the name of the trace to be up
 
 The following `opts` are supported:
 
-- `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
-- `opts.markersize`  : marker size (`number`; default = `'10'`)
-- `opts.markercolor` : color per marker. (`torch.*Tensor`; default = `nil`)
-- `opts.legend`      : `table` containing legend names
-- `opts.textlabels`  : text label for each point (`list`: default = `None`)
-- `opts.layoutopts`  : dict of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
-- `opts.traceopts`   : dict mapping trace names or indices to dicts of additional options that the graph backend accepts. For example `traceopts = {'plotly': {'myTrace': {'mode': 'markers'}}}`.
-- `opts.webgl`       : use WebGL for plotting (`boolean`; default = `false`). It is faster if a plot contains too many points. Use sparingly as browsers won't allow more than a couple of WebGL contexts on a single page.
+- `opts.markersymbol`     : marker symbol (`string`; default = `'dot'`)
+- `opts.markersize`       : marker size (`number`; default = `'10'`)
+- `opts.markercolor`      : color per marker. (`torch.*Tensor`; default = `nil`)
+- `opts.markerborderwidth`: marker border line width (`float`; default = 0.5)
+- `opts.legend`           : `table` containing legend names
+- `opts.textlabels`       : text label for each point (`list`: default = `None`)
+- `opts.layoutopts`       : dict of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
+- `opts.traceopts`        : dict mapping trace names or indices to dicts of additional options that the graph backend accepts. For example `traceopts = {'plotly': {'myTrace': {'mode': 'markers'}}}`.
+- `opts.webgl`            : use WebGL for plotting (`boolean`; default = `false`). It is faster if a plot contains too many points. Use sparingly as browsers won't allow more than a couple of WebGL contexts on a single page.
 
 `opts.markercolor` is a Tensor with Integer values. The tensor can be of size `N` or `N x 3` or `K` or `K x 3`.
 

--- a/example/demo.py
+++ b/example/demo.py
@@ -189,6 +189,7 @@ def run_demo(viz):
         opts=dict(
             markersize=10,
             markercolor=np.floor(np.random.random((2, 3)) * 255),
+            markerborderwidth=0,
         ),
     )
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -296,6 +296,11 @@ def _assert_opts(opts):
             and opts.get('markersize') > 0, \
             'marker size should be a positive number'
 
+    if opts.get('markerborderwidth'):
+        assert isnum(opts.get('markerborderwidth')) \
+            and opts.get('markerborderwidth') >= 0, \
+            'marker border width should be a nonnegative number'
+
     if opts.get('columnnames'):
         assert isinstance(opts.get('columnnames'), list), \
             'columnnames should be a list with column names'
@@ -1456,12 +1461,13 @@ class Visdom(object):
 
         The following `opts` are supported:
 
-        - `opts.markersymbol`: marker symbol (`string`; default = `'dot'`)
-        - `opts.markersize`  : marker size (`number`; default = `'10'`)
-        - `opts.markercolor` : marker color (`np.array`; default = `None`)
-        - `opts.dash`        : dash type (`np.array`; default = 'solid'`)
-        - `opts.textlabels`  : text label for each point (`list`: default = `None`)
-        - `opts.legend`      : `list` containing legend names
+        - `opts.markersymbol`     : marker symbol (`string`; default = `'dot'`)
+        - `opts.markersize`       : marker size (`number`; default = `'10'`)
+        - `opts.markercolor`      : marker color (`np.array`; default = `None`)
+        - `opts.markerborderwidth`: marker border line width (`float`; default = 0.5)
+        - `opts.dash`             : dash type (`np.array`; default = 'solid'`)
+        - `opts.textlabels`       : text label for each point (`list`: default = `None`)
+        - `opts.legend`           : `list` containing legend names
         """
         if update == 'remove':
             assert win is not None
@@ -1529,6 +1535,7 @@ class Visdom(object):
             opts['mode'] = opts.get('mode', 'markers+text')
         opts['markersymbol'] = opts.get('markersymbol', 'dot')
         opts['markersize'] = opts.get('markersize', 10)
+        opts['markerborderwidth'] = opts.get('markerborderwidth', 0.5)
 
         if opts.get('markercolor') is not None:
             opts['markercolor'] = _markerColorCheck(
@@ -1591,7 +1598,7 @@ class Visdom(object):
                         'color': mc[k] if mc is not None else None,
                         'line': {
                             'color': '#000000',
-                            'width': 0.5,
+                            'width': opts.get('markerborderwidth'),
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Provide a way to change the width of the black border around every point in a
scatter plot from 0.5. A new opt `opts.markerborderwidth` provides the new value.

## Motivation and Context
If you want to use color in a meaningful way in a scatter plot, the
hardcoded black border gets in the way. This is worse when you have
a lot of points in a scatter plot. One use case is plotting an RGB
pointcloud of a scene - every point has a meaningful color, and we
don't want to see black.

I think this is the minimum change to fix the following issue.
https://github.com/facebookresearch/visdom/issues/623

## How Has This Been Tested?
Running on Linux, I observe the difference in safari.
https://snipboard.io/fkPFgi.jpg shows two scatterplots in the demo, one of which has no border. The same works for 3d plots. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.