### PR TITLE
Unexpect Error due to MathJax Extension removed

### DIFF
--- a/py/visdom/static/index.html
+++ b/py/visdom/static/index.html
@@ -30,7 +30,7 @@ LICENSE file in the root directory of this source tree.
     <script src={{ static_url("js/layout_bin_packer.js") }}></script>
 
     <!-- Mathjax -->
-    <script type="text/javascript" async src={{ static_url("js/mathjax-MathJax.js") }}></script>
+    <script type="text/html" async src={{ static_url("js/mathjax-MathJax.js") }}></script>
 
     <!-- Plotly -->
     <script src={{ static_url("js/plotly-plotly.min.js") }}></script>


### PR DESCRIPTION
The issues in the console log was remove.
I got the reference from here: support.google.com/chrome/forum/AAAAP1KN0B0Uj6DitMGK1A

## Description
There was an error:
![image](https://user-images.githubusercontent.com/33365560/77549134-7ba93e80-6ed5-11ea-9836-efe7cfe607b8.png)
After my edit the error is gone:
![image](https://user-images.githubusercontent.com/33365560/77549206-91b6ff00-6ed5-11ea-9963-075be3752b8b.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
