### PR TITLE
Removed MathJax js console error issue

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1653,8 +1653,8 @@ def download_scripts(proxies=None, install_dir=None):
             'react-dom.min.js',
         '%sreact-modal@3.1.10/dist/react-modal.min.js' % b:
             'react-modal.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG':  # noqa
-            'mathjax-MathJax.js',
+        #'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG':  # noqa
+            #'mathjax-MathJax.js',
         # here is another url in case the cdn breaks down again.
         # https://raw.githubusercontent.com/plotly/plotly.js/master/dist/plotly.min.js
         'https://cdn.plot.ly/plotly-latest.min.js': 'plotly-plotly.min.js',
@@ -1742,6 +1742,12 @@ def download_scripts(proxies=None, install_dir=None):
             except URLError as exc:
                 logging.error('Error {} while downloading {}'.format(
                     exc.reason, key))
+
+    filename = '%s/static/%s/%s' % (install_dir, "js", "MathJax.js")
+    if not os.path.exists(filename):
+        mathjax_js = requests.get("https://raw.githubusercontent.com/mathjax/MathJax/master/es5/tex-mml-svg.js")#("https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG")
+        with open(filename,"w") as file:
+            file.write(mathjax_js.text)
 
     if not is_built:
         with open(built_path, 'w+') as build_file:

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1653,8 +1653,6 @@ def download_scripts(proxies=None, install_dir=None):
             'react-dom.min.js',
         '%sreact-modal@3.1.10/dist/react-modal.min.js' % b:
             'react-modal.min.js',
-        #'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG':  # noqa
-            #'mathjax-MathJax.js',
         # here is another url in case the cdn breaks down again.
         # https://raw.githubusercontent.com/plotly/plotly.js/master/dist/plotly.min.js
         'https://cdn.plot.ly/plotly-latest.min.js': 'plotly-plotly.min.js',
@@ -1743,9 +1741,9 @@ def download_scripts(proxies=None, install_dir=None):
                 logging.error('Error {} while downloading {}'.format(
                     exc.reason, key))
 
-    filename = '%s/static/%s/%s' % (install_dir, "js", "MathJax.js")
+    filename = '%s/static/%s/%s' % (install_dir, "js", "mathjax_MathJax.js")
     if not os.path.exists(filename):
-        mathjax_js = requests.get("https://raw.githubusercontent.com/mathjax/MathJax/master/es5/tex-mml-svg.js")#("https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG")
+        mathjax_js = requests.get("https://raw.githubusercontent.com/mathjax/MathJax/master/es5/tex-mml-svg.js")
         with open(filename,"w") as file:
             file.write(mathjax_js.text)
 

--- a/py/visdom/static/index.html
+++ b/py/visdom/static/index.html
@@ -33,7 +33,7 @@ LICENSE file in the root directory of this source tree.
     <script src={{ static_url("js/plotly-plotly.min.js") }}></script>
 
     <!-- Mathjax -->
-    <script type="text/javascript" async src={{ static_url("js/MathJax.js") }}></script>
+    <script type="text/javascript" async src={{ static_url("js/mathjax_MathJax.js") }}></script>
 
     <!-- Custom styles for this template -->
     <script>

--- a/py/visdom/static/index.html
+++ b/py/visdom/static/index.html
@@ -29,11 +29,11 @@ LICENSE file in the root directory of this source tree.
     <script src={{ static_url("js/react-dom.min.js") }}></script>
     <script src={{ static_url("js/layout_bin_packer.js") }}></script>
 
-    <!-- Plotly -->
-    <script src={{ static_url("js/plotly-plotly.min.js") }}></script>
-
     <!-- Mathjax -->
     <script type="text/javascript" async src={{ static_url("js/mathjax_MathJax.js") }}></script>
+
+    <!-- Plotly -->
+    <script src={{ static_url("js/plotly-plotly.min.js") }}></script>
 
     <!-- Custom styles for this template -->
     <script>

--- a/py/visdom/static/index.html
+++ b/py/visdom/static/index.html
@@ -29,11 +29,11 @@ LICENSE file in the root directory of this source tree.
     <script src={{ static_url("js/react-dom.min.js") }}></script>
     <script src={{ static_url("js/layout_bin_packer.js") }}></script>
 
-    <!-- Mathjax -->
-    <script type="text/javascript" async src={{ static_url("js/mathjax-MathJax.js") }}></script>
-
     <!-- Plotly -->
     <script src={{ static_url("js/plotly-plotly.min.js") }}></script>
+
+    <!-- Mathjax -->
+    <script type="text/javascript" async src={{ static_url("js/MathJax.js") }}></script>
 
     <!-- Custom styles for this template -->
     <script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Mathjax error were visible in the console and now the error is gone.

## Description
<!--- Describe your changes in detail -->
Mathjax error were visible in the console and now the error is gone.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There were many issues regarding the js library used in the visdom and it was showing console error. I do not like the console errors. Hence, thought of removing it.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
