### PR TITLE
Fix for client polling feature when using with user authentication (visdom.server)

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -578,10 +578,6 @@ class ClientSocketWrapper():
             ))
 
     def open(self):
-        if self.login_enabled and not self.current_user:
-            print("AUTH Failed in SocketHandler")
-            self.close()
-            return
         self.sid = get_rand_id()
         if self not in list(self.subs.values()):
             self.eid = 'main'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix for the issue when visdom.server was throwing exception when using both flags `-use_frontend_client_polling` and `-enable_login`

## Description
<!--- Describe your changes in detail -->
The changes are made exactly as @JackUrb suggested here https://github.com/facebookresearch/visdom/pull/633#issuecomment-691235257 , namely getting rid of redundant check for authorization

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The issue has been reported here https://github.com/facebookresearch/visdom/pull/633#issuecomment-691152479

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->
I used simple script continously plotting random data to server. For testing I used all combinations of flags `-use_frontend_client_polling` and `-enable_login` when running visdom server.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
