### PR TITLE
Update the license metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ Arguments:
 - `log_filename`: log file to replay the contents of.
 
 ## License
-visdom is Creative Commons Attribution-NonCommercial 4.0 International Public licensed, as found in the LICENSE file.
+visdom is Apache 2.0 licensed, as found in the LICENSE file.
 
 ## Note on Lua Torch Support
 Support for Lua Torch was deprecated following `v0.1.8.4`. If you'd like to use torch support, you'll need to download that release. You can follow the usage instructions there, but it is no longer officially supported.

--- a/js/lasso.js
+++ b/js/lasso.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright 2017-present, The Visdom Authors
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import * as d3 from 'd3-selection';
 import { dispatch as d3dispatch } from 'd3-dispatch';
 import { drag as d3drag } from 'd3-drag';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "main": "index.js",
-  "license": "CC-BY-NC-4.0",
+  "license": "Apache-2.0",
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.3",

--- a/py/visdom/extra_deps/__init__.py
+++ b/py/visdom/extra_deps/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-present, Facebook, Inc.
+# Copyright 2017-present, The Visdom Authors
 # All rights reserved.
 #
 # This source code is licensed under the license found in the

--- a/py/visdom/static/css/login.css
+++ b/py/visdom/static/css/login.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-present, Facebook, Inc.
+ * Copyright 2017-present, The Visdom Authors
  * All rights reserved.
  *
  * This source code is licensed under the license found in the

--- a/py/visdom/static/css/style.css
+++ b/py/visdom/static/css/style.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-present, Facebook, Inc.
+ * Copyright 2017-present, The Visdom Authors
  * All rights reserved.
  *
  * This source code is licensed under the license found in the

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     url='https://github.com/facebookresearch/visdom',
     description='A tool for visualizing live, rich data for Torch and Numpy',
     long_description=readme,
-    license='CC-BY-NC-4.0',
+    license='Apache-2.0',
 
     # Package info
     packages=['visdom'],

--- a/th/visdom-scm-1.rockspec
+++ b/th/visdom-scm-1.rockspec
@@ -11,7 +11,7 @@ description = {
       A tool for visualizing live, rich data for Torch and Numpy.
    ]],
    homepage = "https://github.com/facebookresearch/visdom",
-   license = "Creative Commons Attribution-NonCommercial 4.0 International Public License"
+   license = "Apache 2.0"
 }
 
 dependencies = {


### PR DESCRIPTION
## Description

Change the license metadata in the README and luarocks files.

## Motivation and Context

In commit cb74886748718ab254c3673ca598012622a0b8cb, visdom was relicensed
to the Apache 2.0 license, but the license metadata in was not updated at
the same time. This could be confusing to downstream redistributors and
to users so it would be best to have consistent license information.

## How Has This Been Tested?

This change was not tested since it only affects license metadata.

## Types of changes

- [x] Documentation fix (non-breaking change which fixes docs)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

The checklist in the pull request template is not applicable.