### PR TITLE
check types with isinstance; allow tuple, where possible

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -140,7 +140,7 @@ def _title2str(opts):
 
 
 def _scrub_dict(d):
-    if type(d) is dict:
+    if isinstance(d, dict):
         return {k: _scrub_dict(v) for k, v in list(d.items())
                 if v is not None and _scrub_dict(v) is not None}
     else:
@@ -1561,9 +1561,10 @@ class Visdom(object):
         _assert_opts(opts)
 
         if opts.get('legend'):
-            assert type(opts['legend']) == list and K <= len(opts['legend']), \
-                'largest label should not be greater than size of the ' \
-                'legends table'
+            assert isinstance(opts['legend'], (tuple, list)) \
+                   and K <= len(opts['legend']), \
+                   'largest label should not be greater than size of ' \
+                   'the legends table'
 
         data = []
         trace_opts = opts.get('traceopts', {'plotly': {}})['plotly']

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1469,7 +1469,7 @@ class Visdom(object):
         - `opts.markerborderwidth`: marker border line width (`float`; default = 0.5)
         - `opts.dash`             : dash type (`np.array`; default = 'solid'`)
         - `opts.textlabels`       : text label for each point (`list`: default = `None`)
-        - `opts.legend`           : `list` containing legend names
+        - `opts.legend`           : `list` or `tuple` containing legend names
         """
         if update == 'remove':
             assert win is not None
@@ -1670,7 +1670,7 @@ class Visdom(object):
         - `opts.markersize`  : marker size (`number`; default = `'10'`)
         - `opts.linecolor`   : line colors (`np.array`; default = None)
         - `opts.dash`        : line dash type (`np.array`; default = None)
-        - `opts.legend`      : `list` containing legend names
+        - `opts.legend`      : `list` or `tuple` containing legend names
 
         If `update` is specified, the figure will be updated without
         creating a new plot -- this can be used for efficient updating.

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -407,7 +407,7 @@ class VisSocketWrapper():
         to_send = []
         while len(self.messages) > 0:
             message = self.messages.pop()
-            if type(message) is dict:
+            if isinstance(message, dict):
                 # Not all messages are being formatted the same way (JSON)
                 # TODO investigate
                 message = json.dumps(message)
@@ -656,7 +656,7 @@ class ClientSocketWrapper():
         to_send = []
         while len(self.messages) > 0:
             message = self.messages.pop()
-            if type(message) is dict:
+            if isinstance(message, dict):
                 # Not all messages are being formatted the same way (JSON)
                 # TODO investigate
                 message = json.dumps(message)
@@ -769,7 +769,7 @@ def window(args):
 
 def broadcast(self, msg, eid):
     for s in self.subs:
-        if type(self.subs[s].eid) is list:
+        if isinstance(self.subs[s].eid, dict):
             if eid in self.subs[s].eid:
                 self.subs[s].write_message(msg)
         else:


### PR DESCRIPTION
Dear Jack,

I stumbled upon a bad practice of checking the object type with `type(x) == y`. Also, a handy-used scenario is when the user populates a dict with keys as legend labels and values as the payload:
```python
names, values = list(zip(*dict.items()))
viz.line(..., opts=dict(legend=names))
```
In short, legend sometimes can be passed as a tuple rather than a list, and I thought there is nothing wrong with allowing tuples.

## How Has This Been Tested?
Tested by running the demo script.

## Types of changes
- [x] Other (non-breaking change which improves code readability)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.

P.S. It ain't much, but it's honest work.
P.P.S. When I was fixing the bad practice here and there, I noticed some other small issues with the coding style like code duplication, old python usage, etc. At first, I felt tempted to dive deeply into fixing them all but noticed https://github.com/facebookresearch/visdom/pull/675, which, of course, should be merged before any further sugar-code fixes.
P.P.P.S. One could set up Travis or CircleCI builds like I'm doing [here](https://github.com/dizcza/pytorch-mighty/blob/master/mighty/tests/test_trainer.py#L24-L26) to finally test the changes properly on each PR. I can write CircleCI build script if you set up a server.

Best,
Danylo
